### PR TITLE
Make client compatible with change to dockerclient api

### DIFF
--- a/container/client.go
+++ b/container/client.go
@@ -153,7 +153,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 func (client dockerClient) RemoveImage(c Container) error {
 	imageID := c.ImageID()
 	log.Infof("Removing image %s", imageID)
-	_, err := client.api.RemoveImage(imageID)
+	_, err := client.api.RemoveImage(imageID,false)
 	return err
 }
 

--- a/container/client.go
+++ b/container/client.go
@@ -30,19 +30,21 @@ type Client interface {
 
 // NewClient returns a new Client instance which can be used to interact with
 // the Docker API.
-func NewClient(dockerHost string, tlsConfig *tls.Config, pullImages bool) Client {
+func NewClient(dockerHost string, tlsConfig *tls.Config, username string, password string, pullImages bool) Client {
 	docker, err := dockerclient.NewDockerClient(dockerHost, tlsConfig)
 
 	if err != nil {
 		log.Fatalf("Error instantiating Docker client: %s", err)
 	}
 
-	return dockerClient{api: docker, pullImages: pullImages}
+	return dockerClient{api: docker, pullImages: pullImages, username: username, password: password}
 }
 
 type dockerClient struct {
 	api        dockerclient.Client
 	pullImages bool
+	username string
+	password string
 }
 
 func (client dockerClient) ListContainers(fn Filter) ([]Container, error) {
@@ -131,8 +133,12 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 	imageName := c.ImageName()
 
 	if client.pullImages {
+		var a *dockerclient.AuthConfig = nil
+		if client.username!="" {
+			a = &dockerclient.AuthConfig{Username: client.username, Password: client.password, Email: ""}
+		}
 		log.Debugf("Pulling %s for %s", imageName, c.Name())
-		if err := client.api.PullImage(imageName, nil); err != nil {
+		if err := client.api.PullImage(imageName, a); err != nil {
 			return false, err
 		}
 	}

--- a/container/client.go
+++ b/container/client.go
@@ -133,7 +133,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 	imageName := c.ImageName()
 
 	if client.pullImages {
-		var a *dockerclient.AuthConfig = nil
+		var a *dockerclient.AuthConfig
 		if client.username!="" {
 			a = &dockerclient.AuthConfig{Username: client.username, Password: client.password, Email: ""}
 		}

--- a/main.go
+++ b/main.go
@@ -89,6 +89,14 @@ func main() {
 			Name:  "debug",
 			Usage: "enable debug mode with verbose logging",
 		},
+		cli.StringFlag{
+			Name:  "username, u",
+			Usage: "username for registry authentication",
+		},
+		cli.StringFlag{
+			Name:  "password, p",
+			Usage: "username for registry authentication",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -110,7 +118,7 @@ func before(c *cli.Context) error {
 		return err
 	}
 
-	client = container.NewClient(c.GlobalString("host"), tls, !c.GlobalBool("no-pull"))
+	client = container.NewClient(c.GlobalString("host"), tls, c.GlobalString("username"), c.GlobalString("password"), !c.GlobalBool("no-pull"))
 
 	handleSignals()
 	return nil


### PR DESCRIPTION
The dockerclient api has been updated with a new mandatory parameter - I propose to just default to force=false
Added support for registry authentication
