### PR TITLE
Configure with ENV vars and allow skipping of restart

### DIFF
--- a/actions/update.go
+++ b/actions/update.go
@@ -34,7 +34,7 @@ func containerFilter(names []string) container.Filter {
 // used to start those containers have been updated. If a change is detected in
 // any of the images, the associated containers are stopped and restarted with
 // the new image.
-func Update(client container.Client, names []string, cleanup bool) error {
+func Update(client container.Client, names []string, cleanup bool, noRestart bool) error {
 	log.Info("Checking containers for updated images")
 
 	containers, err := client.ListContainers(containerFilter(names))
@@ -86,8 +86,10 @@ func Update(client container.Client, names []string, cleanup bool) error {
 				}
 			}
 
-			if err := client.StartContainer(container); err != nil {
-				log.Error(err)
+			if !noRestart {
+				if err := client.StartContainer(container); err != nil {
+					log.Error(err)
+				}
 			}
 
 			if cleanup {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 	client       container.Client
 	pollInterval time.Duration
 	cleanup      bool
+	noRestart    bool
 )
 
 func init() {
@@ -49,17 +50,25 @@ func main() {
 			EnvVar: "DOCKER_HOST",
 		},
 		cli.IntFlag{
-			Name:  "interval, i",
-			Usage: "poll interval (in seconds)",
-			Value: 300,
+			Name:   "interval, i",
+			Usage:  "poll interval (in seconds)",
+			Value:  300,
+			EnvVar: "WATCHTOWER_POLL_INTERVAL",
 		},
 		cli.BoolFlag{
-			Name:  "no-pull",
-			Usage: "do not pull new images",
+			Name:   "no-pull",
+			Usage:  "do not pull new images",
+			EnvVar: "WATCHTOWER_NO_PULL",
 		},
 		cli.BoolFlag{
-			Name:  "cleanup",
-			Usage: "remove old images after updating",
+			Name:   "no-restart",
+			Usage:  "do not restart containers",
+			EnvVar: "WATCHTOWER_NO_PULL",
+		},
+		cli.BoolFlag{
+			Name:   "cleanup",
+			Usage:  "remove old images after updating",
+			EnvVar: "WATCHTOWER_CLEANUP",
 		},
 		cli.BoolFlag{
 			Name:  "tls",
@@ -103,6 +112,7 @@ func before(c *cli.Context) error {
 
 	pollInterval = time.Duration(c.Int("interval")) * time.Second
 	cleanup = c.GlobalBool("cleanup")
+	noRestart = c.GlobalBool("no-restart")
 
 	// Set-up container client
 	tls, err := tlsConfig(c)
@@ -125,7 +135,7 @@ func start(c *cli.Context) {
 
 	for {
 		wg.Add(1)
-		if err := actions.Update(client, names, cleanup); err != nil {
+		if err := actions.Update(client, names, cleanup, noRestart); err != nil {
 			fmt.Println(err)
 		}
 		wg.Done()

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 		cli.BoolFlag{
 			Name:   "no-restart",
 			Usage:  "do not restart containers",
-			EnvVar: "WATCHTOWER_NO_PULL",
+			EnvVar: "WATCHTOWER_NO_RESTART",
 		},
 		cli.BoolFlag{
 			Name:   "cleanup",


### PR DESCRIPTION
This allows us to use ENV vars to configure most options. In the case when using an orchestration framework access to changing the command isn't viable however ENV vars can be easily utilised to configure the container.

In the same scenario not restarting allows the orchestration tools to handle starting the container itself.
