### PR TITLE
Allow private image pulls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM centurylink/ca-certs
-MAINTAINER CenturyLink Labs <innovationslab@ctl.io>
-LABEL "com.centurylinklabs.watchtower"="true"
+FROM ubuntu:14.04
 
 COPY watchtower /
 ENTRYPOINT ["/watchtower"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Watchtower
 ![Watchtower](http://panamax.ca.tier3.io/zodiac/logo-watchtower_thumb.png)
 
-[![Circle CI](https://circleci.com/gh/CenturyLinkLabs/watchtower.svg?style=svg)](https://circleci.com/gh/CenturyLinkLabs/watchtower)&nbsp; 
+[![Circle CI](https://circleci.com/gh/CenturyLinkLabs/watchtower.svg?style=svg)](https://circleci.com/gh/CenturyLinkLabs/watchtower)&nbsp;
 [![GoDoc](https://godoc.org/github.com/CenturyLinkLabs/watchtower?status.svg)](https://godoc.org/github.com/CenturyLinkLabs/watchtower)&nbsp;
 [![](https://badge.imagelayers.io/centurylink/watchtower:latest.svg)](https://imagelayers.io/?images=centurylink/watchtower:latest 'Get your own badge on imagelayers.io')
 
@@ -37,6 +37,16 @@ docker run -d \
   --name watchtower \
   -v /var/run/docker.sock:/var/run/docker.sock \
   centurylink/watchtower
+```
+
+For private images:
+
+```
+docker run -d \
+  --name watchtower \
+  -e REPO_USER="username" -e REPO_PASS="pass" -e REPO_EMAIL="email" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  drud/watchtower container_to_watch --debug
 ```
 
 ### Arguments

--- a/container/client.go
+++ b/container/client.go
@@ -111,7 +111,7 @@ func (client dockerClient) StartContainer(c Container) error {
 
 	log.Infof("Starting %s", name)
 
-	newContainerID, err := client.api.CreateContainer(config, name)
+	newContainerID, err := client.api.CreateContainer(config, name, nil)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 func (client dockerClient) RemoveImage(c Container) error {
 	imageID := c.ImageID()
 	log.Infof("Removing image %s", imageID)
-	_, err := client.api.RemoveImage(imageID)
+	_, err := client.api.RemoveImage(imageID, true)
 	return err
 }
 

--- a/container/client.go
+++ b/container/client.go
@@ -13,6 +13,12 @@ const (
 	defaultStopSignal = "SIGTERM"
 )
 
+var auth = dockerclient.AuthConfig{
+	Username: "",
+	Password: "",
+	Email:    "",
+}
+
 // A Filter is a prototype for a function that can be used to filter the
 // results from a call to the ListContainers() method on the Client.
 type Filter func(Container) bool
@@ -111,7 +117,7 @@ func (client dockerClient) StartContainer(c Container) error {
 
 	log.Infof("Starting %s", name)
 
-	newContainerID, err := client.api.CreateContainer(config, name)
+	newContainerID, err := client.api.CreateContainer(config, name, &auth)
 	if err != nil {
 		return err
 	}
@@ -132,7 +138,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 
 	if client.pullImages {
 		log.Debugf("Pulling %s for %s", imageName, c.Name())
-		if err := client.api.PullImage(imageName, nil); err != nil {
+		if err := client.api.PullImage(imageName, &auth); err != nil {
 			return false, err
 		}
 	}
@@ -153,7 +159,7 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 func (client dockerClient) RemoveImage(c Container) error {
 	imageID := c.ImageID()
 	log.Infof("Removing image %s", imageID)
-	_, err := client.api.RemoveImage(imageID)
+	_, err := client.api.RemoveImage(imageID, true)
 	return err
 }
 

--- a/container/client.go
+++ b/container/client.go
@@ -3,6 +3,7 @@ package container
 import (
 	"crypto/tls"
 	"fmt"
+	"os"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -13,11 +14,9 @@ const (
 	defaultStopSignal = "SIGTERM"
 )
 
-var auth = dockerclient.AuthConfig{
-	Username: "",
-	Password: "",
-	Email:    "",
-}
+var username = os.Getenv("REPO_USER")
+var password = os.Getenv("REPO_PASS")
+var email = os.Getenv("REPO_EMAIL")
 
 // A Filter is a prototype for a function that can be used to filter the
 // results from a call to the ListContainers() method on the Client.
@@ -117,7 +116,18 @@ func (client dockerClient) StartContainer(c Container) error {
 
 	log.Infof("Starting %s", name)
 
-	newContainerID, err := client.api.CreateContainer(config, name, &auth)
+	var err error
+	var newContainerID string
+	if username != "" && password != "" && email != "" {
+		auth := dockerclient.AuthConfig{
+			Username: username,
+			Password: password,
+			Email:    email,
+		}
+		newContainerID, err = client.api.CreateContainer(config, name, &auth)
+	} else {
+		newContainerID, err = client.api.CreateContainer(config, name, nil)
+	}
 
 	if err != nil {
 		return err
@@ -139,9 +149,22 @@ func (client dockerClient) IsContainerStale(c Container) (bool, error) {
 
 	if client.pullImages {
 		log.Debugf("Pulling %s for %s", imageName, c.Name())
-		if err := client.api.PullImage(imageName, &auth); err != nil {
-			return false, err
+
+		if username != "" && password != "" && email != "" {
+			auth := dockerclient.AuthConfig{
+				Username: username,
+				Password: password,
+				Email:    email,
+			}
+			if err := client.api.PullImage(imageName, &auth); err != nil {
+				return false, err
+			}
+		} else {
+			if err := client.api.PullImage(imageName, nil); err != nil {
+				return false, err
+			}
 		}
+
 	}
 
 	newImageInfo, err := client.api.InspectImage(imageName)


### PR DESCRIPTION
This PR allows you to pass docker hub credentials to the watchtower image as ENV vars and thus find images that are private.
