### PR TITLE
revert base image to centurylink/ca-certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM centurylink/ca-certs
 
 COPY watchtower /
 ENTRYPOINT ["/watchtower"]


### PR DESCRIPTION
this was accidentally changed to ubuntu by a PR I made
