### PR TITLE
BuildFix:  Fixed Parameters of NewNativeStore call

### DIFF
--- a/container/trust.go
+++ b/container/trust.go
@@ -87,7 +87,7 @@ func ParseServerAddress(ref string) (string, error) {
 // on the settings provided in the configuration file.
 func CredentialsStore(configFile configfile.ConfigFile) credentials.Store {
 	if configFile.CredentialsStore != "" {
-		return credentials.NewNativeStore(&configFile)
+		return credentials.NewNativeStore(&configFile, configFile.CredentialsStore)
 	}
 	return credentials.NewFileStore(&configFile)
 }


### PR DESCRIPTION
NewNativeStore has to be called with the CredentialsStore from the configfile. See also https://github.com/docker/docker/commit/07c4b4124b46be30ea3ac7d114c44c4f911ca182#diff-b082736d194e2fdfc6aca9d0c86a781bL26