### PR TITLE
Set minimum required API Version of docker to 1.24, this basically me…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ docker run --rm v2tec/watchtower --help
 * `--no-pull` Do not pull new images. When this flag is specified, watchtower will not attempt to pull new images from the registry. Instead it will only monitor the local image cache for changes. Use this option if you are building new images directly on the Docker host without pushing them to a registry.
 * `--cleanup` Remove old images after updating. When this flag is specified, watchtower will remove the old image after restarting a container with a new image. Use this option to prevent the accumulation of orphaned images on your system as containers are updated.
 * `--tlsverify` Use TLS when connecting to the Docker socket and verify the server's certificate.
-* `--apiversion` Specify the minimum docker api version. watchtower will only communicate with docker servers running this api version or later.
 * `--debug` Enable debug mode. When this option is specified you'll see more verbose logging in the watchtower log file.
 * `--help` Show documentation about the supported flags.
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/stffabi/watchtower
+package: github.com/v2tec/watchtower
 import:
 - package: github.com/Sirupsen/logrus
   version: ~0.11.x

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ import (
 	"github.com/v2tec/watchtower/container"
 )
 
+// DockerAPIMinVersion is the version of the docker API, which is minimally required by
+// watchtower. Currently we require at least API 1.24 and therefore Docker 1.12 or later.
+const DockerAPIMinVersion string = "1.24"
+
 var (
 	client       container.Client
 	scheduleSpec string
@@ -74,11 +78,6 @@ func main() {
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "enable debug mode with verbose logging",
-		},
-		cli.StringFlag{
-			Name:   "apiversion",
-			Usage:  "the version of the docker api",
-			EnvVar: "DOCKER_API_VERSION",
 		},
 	}
 
@@ -190,7 +189,7 @@ func envConfig(c *cli.Context) error {
 
 	err = setEnvOptStr("DOCKER_HOST", c.GlobalString("host"))
 	err = setEnvOptBool("DOCKER_TLS_VERIFY", c.GlobalBool("tlsverify"))
-	err = setEnvOptStr("DOCKER_API_VERSION", c.GlobalString("apiversion"))
+	err = setEnvOptStr("DOCKER_API_VERSION", DockerAPIMinVersion)
 
 	return err
 }


### PR DESCRIPTION
…ans we require at least docker 1.12.x or newer, therefore we also support docker 1.13.x.

Fixes #51 