### PR TITLE
set default registry server-addres for Docker HUB images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 watchtower
 vendor
 .glide
+debug
+.vscode

--- a/container/container.go
+++ b/container/container.go
@@ -61,6 +61,10 @@ func (c Container) ImageName() string {
 		imageName = fmt.Sprintf("%s:latest", imageName)
 	}
 
+	if strings.Count(imageName, "/") == 1 {
+		imageName = strings.Join([]string{"index.docker.io/", imageName}, "")
+	}
+
 	return imageName
 }
 


### PR DESCRIPTION
Current Docker HUB users can't pull private DockerHUB images without specifying docker image with server path like "index.docker.io/rreinurm/private-image". But in docker-compose and docker commands don't require to explicitly specify DockerHUB registry-address for private images, I would just use imagename "rreinurm/private-image".

This pull request appends "index.docker.io" as a default registry-server address to the docker image name to be able to pull them with same ux as docker commands.