### PR TITLE
GoReleaser for release builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 watchtower
 vendor
 .glide
+dist

--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,30 @@
 machine:
   services:
     - docker
+  environment:
+    IS_RELEASE: $(if [ "$CIRCLE_TAG" != "" ] ; then echo release; else echo ci; fi;)
+    BUILD_IMAGE: v2tec/gobuilder:0.1.0_go1.7.4-glide0.12.3-goreleaser0.6.2
 
 dependencies:
   override:
-    - docker pull centurylink/golang-builder:latest
-    - go get -u github.com/Masterminds/glide
+    - git fetch --tags
+    - docker pull $BUILD_IMAGE
+
+compile:
+  override:
+    - docker run -v "$PWD":/src -e GITHUB_TOKEN=$GITHUB_TOKEN $BUILD_IMAGE $IS_RELEASE $CIRCLE_BRANCH-$CIRCLE_SHA1
 
 test:
   override:
-    - glide install
-    - docker run -v $(pwd):/src centurylink/golang-builder:latest --test
+    - echo "Tests included in compile step."
 
 deployment:
   ci:
     branch: /.*/
     commands:
-      - cp -r ./watchtower $CIRCLE_ARTIFACTS
+      - cp -r ./dist/* $CIRCLE_ARTIFACTS
+  release:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    owner: v2tec
+    commands:
+      - cp -r ./dist/* $CIRCLE_ARTIFACTS

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,55 @@
+# Build customization
+build:
+  # Path to main.go file.
+  # Default is `main.go`
+  main: ./main.go
+
+  # Custom ldflags.
+  # Default is `-s -w`
+  ldflags: -s -w
+
+  # GOOS list to build in.
+  # For more info refer to https://golang.org/doc/install/source#environment
+  # Defaults are darwin and linux
+  goos:
+    - linux
+
+  # GOARCH to build in.
+  # For more info refer to https://golang.org/doc/install/source#environment
+  # Defaults are 386 and amd64
+  goarch:
+    - amd64
+
+# Archive customization
+archive:
+  # You can change the name of the archive.
+  # This is parsed with Golang template engine and the following variables
+  # are available:
+  # - BinaryName
+  # - Version
+  # - Os
+  # - Arch
+  # The default is `{{.BinaryName}}_{{.Os}}_{{.Arch}}`
+  name_template: "{{.BinaryName}}_{{.Os}}_{{.Arch}}"
+
+  # Archive format. Valid options are `tar.gz` and `zip`.
+  # Default is `zip`
+  format: tar.gz
+
+  # Replacements for GOOS and GOARCH on the archive name.
+  # The keys should be valid GOOS or GOARCH values followed by your custom
+  # replacements.
+  # By default, `replacements` replace GOOS and GOARCH values with valid outputs
+  # of `uname -s` and `uname -m` respectively.
+  replacements:
+    arm: arm
+    amd64: amd64
+    386: 386
+    darwin: macOS
+    linux: linux
+
+  # Additional files you want to add to the archive.
+  # Defaults are any files matching `LICENCE*`, `LICENSE*`,
+  # `README*` and `CHANGELOG*` (case-insensitive)
+  files:
+    - LICENSE.md

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 // watchtower. Currently we require at least API 1.24 and therefore Docker 1.12 or later.
 const DockerAPIMinVersion string = "1.24"
 
+var version = "master"
+
 var (
 	client       container.Client
 	scheduleSpec string
@@ -34,6 +36,7 @@ func init() {
 func main() {
 	app := cli.NewApp()
 	app.Name = "watchtower"
+	app.Version = version
 	app.Usage = "Automatically update running Docker containers"
 	app.Before = before
 	app.Action = start


### PR DESCRIPTION
- Use GoBuilder container for building and release tags with goreleaser.
- Add version to cli.