### PR TITLE
Check for host network mode

### DIFF
--- a/container/client.go
+++ b/container/client.go
@@ -140,18 +140,22 @@ func (client dockerClient) StartContainer(c Container) error {
 		return err
 	}
 
-	for k := range simpleNetworkConfig.EndpointsConfig {
-		err = client.api.NetworkDisconnect(bg, k, creation.ID, true)
-		if err != nil {
-			return err
-		}
-	}
+	if !(hostConfig.NetworkMode.IsHost()) {
 
-	for k, v := range networkConfig.EndpointsConfig {
-		err = client.api.NetworkConnect(bg, k, creation.ID, v)
-		if err != nil {
-			return err
+		for k := range simpleNetworkConfig.EndpointsConfig {
+			err = client.api.NetworkDisconnect(bg, k, creation.ID, true)
+			if err != nil {
+				return err
+			}
 		}
+
+		for k, v := range networkConfig.EndpointsConfig {
+			err = client.api.NetworkConnect(bg, k, creation.ID, v)
+			if err != nil {
+				return err
+			}
+		}
+
 	}
 
 	log.Debugf("Starting container %s (%s)", name, creation.ID)


### PR DESCRIPTION
Searching for the error message from #73 in docker's API allowed me to backtrack the throwing function in NetworkDisconnect which is used in [StartContainer](https://github.com/v2tec/watchtower/blob/master/container/client.go#L144).
After reading a bit around ([here](https://github.com/docker/compose/issues/3532#issuecomment-235935112), [here](https://github.com/jwilder/nginx-proxy/issues/557#issuecomment-244417175) and the [conditions](https://github.com/docker/docker/blob/d8406fd7a029f38ece55421294568045d1c9de92/daemon/container_operations.go#L1030)), I believe host network mode can be only exclusive, so I wrapped the offending code in a conditional block and so far it _seems_ to work for me