### PR TITLE
Build on circleci 2 and goreleaser updated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,30 +1,25 @@
-machine:
-  services:
-    - docker
-  environment:
-    IS_RELEASE: $(if [ "$CIRCLE_TAG" != "" ] ; then echo release; else echo ci; fi;)
-    BUILD_IMAGE: v2tec/gobuilder:0.1.0_go1.7.4-glide0.12.3-goreleaser0.6.2
+version: 2
+jobs:
+  build:
+    docker:
+      - image: v2tec/gobuilder:0.2.0_go1.7.4-glide0.12.3-goreleaser0.40.3-docker17.03.0
+    working_directory: /src
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 17.03.0-ce
+      - run: git fetch --tags
+      - run: |
+          IS_RELEASE=$(if [ "$CIRCLE_TAG" != "" ] ; then echo release; else echo ci; fi;)
+          /build.sh $IS_RELEASE
 
-dependencies:
-  override:
-    - git fetch --tags
-    - docker pull $BUILD_IMAGE
-
-compile:
-  override:
-    - docker run -v "$PWD":/src -e GITHUB_TOKEN=$GITHUB_TOKEN $BUILD_IMAGE $IS_RELEASE $CIRCLE_BRANCH-$CIRCLE_SHA1
-
-test:
-  override:
-    - echo "Tests included in compile step."
-
-deployment:
-  ci:
-    branch: /.*/
-    commands:
-      - cp -r ./dist/* $CIRCLE_ARTIFACTS
-  release:
-    tag: /v[0-9]+(\.[0-9]+)*/
-    owner: v2tec
-    commands:
-      - cp -r ./dist/* $CIRCLE_ARTIFACTS
+      - store_artifacts:
+          path: /src/dist/
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/

--- a/dockerfile/amd64/Dockerfile
+++ b/dockerfile/amd64/Dockerfile
@@ -1,0 +1,4 @@
+FROM centurylink/ca-certs
+LABEL "com.centurylinklabs.watchtower"="true"
+COPY watchtower /
+ENTRYPOINT ["/watchtower"]

--- a/dockerfile/armhf/Dockerfile
+++ b/dockerfile/armhf/Dockerfile
@@ -1,0 +1,4 @@
+FROM centurylink/ca-certs
+LABEL "com.centurylinklabs.watchtower"="true"
+COPY watchtower /
+ENTRYPOINT ["/watchtower"]

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -24,14 +24,8 @@ build:
 # Archive customization
 archive:
   # You can change the name of the archive.
-  # This is parsed with Golang template engine and the following variables
-  # are available:
-  # - BinaryName
-  # - Version
-  # - Os
-  # - Arch
-  # The default is `{{.BinaryName}}_{{.Os}}_{{.Arch}}`
-  name_template: "{{.BinaryName}}_{{.Os}}_{{.Arch}}"
+  # This is parsed with Golang template engine and the following variables.
+  name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
 
   # Archive format. Valid options are `tar.gz` and `zip`.
   # Default is `zip`
@@ -54,3 +48,21 @@ archive:
   # `README*` and `CHANGELOG*` (case-insensitive)
   files:
     - LICENSE.md
+
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    goarm: ''
+    binary: watchtower
+    image: v2tec/watchtower
+    dockerfile: dockerfile/amd64/Dockerfile
+    tag_template: "{{ .Version }}"
+  -
+    goos: linux
+    goarch: arm
+    goarm: 6
+    binary: watchtower
+    image: v2tec/watchtower
+    dockerfile: dockerfile/armhf/Dockerfile
+    tag_template: "armhf-{{ .Version }}"


### PR DESCRIPTION
- Update to circleci 2.0
- Use latest gobuilder with goreleaser which also publishes docker files.