### PR TITLE
Implement support for updating stopped containers

### DIFF
--- a/actions/update.go
+++ b/actions/update.go
@@ -67,6 +67,8 @@ func Update(client container.Client, names []string, cleanup bool, noRestart boo
 			continue
 		}
 
+		container.WasRunning = container.IsRunning()
+
 		if container.Stale {
 			if err := client.StopContainer(container, waitTime); err != nil {
 				log.Error(err)

--- a/container/container.go
+++ b/container/container.go
@@ -27,7 +27,8 @@ func NewContainer(containerInfo *types.ContainerJSON, imageInfo *types.ImageInsp
 
 // Container represents a running Docker container.
 type Container struct {
-	Stale bool
+	Stale      bool
+	WasRunning bool
 
 	containerInfo *types.ContainerJSON
 	imageInfo     *types.ImageInspect
@@ -104,6 +105,13 @@ func (c Container) Links() []string {
 func (c Container) IsWatchtower() bool {
 	val, ok := c.containerInfo.Config.Labels[watchtowerLabel]
 	return ok && val == "true"
+}
+
+// IsRunning returns a boolean flag indicating whether or not the current
+// container is running. The status is determined by the value of the
+// container's "State.Running" property.
+func (c Container) IsRunning() bool {
+	return c.containerInfo.State.Running
 }
 
 // StopSignal returns the custom stop signal (if any) that is encoded in the

--- a/main.go
+++ b/main.go
@@ -62,6 +62,11 @@ func main() {
 			EnvVar: "WATCHTOWER_SCHEDULE",
 		},
 		cli.BoolFlag{
+			Name:   "check-all",
+			Usage:  "check non-running containers",
+			EnvVar: "WATCHTOWER_CHECK_ALL",
+		},
+		cli.BoolFlag{
 			Name:   "no-pull",
 			Usage:  "do not pull new images",
 			EnvVar: "WATCHTOWER_NO_PULL",
@@ -159,7 +164,7 @@ func before(c *cli.Context) error {
 		return err
 	}
 
-	client = container.NewClient(!c.GlobalBool("no-pull"), c.GlobalBool("label-enable"))
+	client = container.NewClient(!c.GlobalBool("no-pull"), c.GlobalBool("label-enable"), c.GlobalBool("check-all"))
 	notifier = notifications.NewNotifier(c)
 
 	return nil


### PR DESCRIPTION
This PR adds a command line flag, "--check-all". If true, the behavior requested by #112 is used (i.e., stopped containers are updated but not restarted). If false, the previous behavior is used (ignore stopped containers entirely).
I attempted to run the tests (with `go test`, as specified in `CONTRIBUTING.md`) but Go couldn't find any test files. I've manually tested the changes and they seem to work well.