### PR TITLE
Add discord notification service

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -199,3 +199,8 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+Watchtower contains code that is licensed under a BSD-license:
+ - Copyright (c) 2009 The Go Authors. All rights reserved.
+   
+   For details see https://golang.org/LICENSE

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Watchtower can send notifications when containers are updated. Notifications are
 The types of notifications to send are passed via the comma-separated option `--notifications` (or corresponding environment variable `WATCHTOWER_NOTIFICATIONS`), which has the following valid values:
 
 * `email` to send notifications via e-mail
+* `discord` to send notifications into Discord channel
 
+### Email
 To receive notifications by email, the following command-line options, or their corresponding environment variables, can be set:
 
 * `--notification-email-from` (env. `WATCHTOWER_NOTIFICATION_EMAIL_FROM`): The e-mail address from which notifications will be sent.
@@ -213,4 +215,12 @@ docker run -d \
   -e WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD=app_password \
   v2tec/watchtower
 ```
+
+### Discord
+To send notifications into Discord channel, the following command-line options, or their corresponding environment variables, can be set:
+
+* `--notification-discord-webhook` (env. `WATCHTOWER_NOTIFICATION_DISCORD_WEBHOOK`): Webhook URL configured in Discord.
+
+[Checkout how to add webhook for channel](https://support.discordapp.com/hc/en-us/articles/228383668)
+
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ The types of notifications to send are passed via the comma-separated option `--
 * `slack` to send notifications through a Slack webhook
 * `discord` to send notifications into Discord channel
 
+### Settings
+
+* `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info` or `debug`.
+
 ### Notifications via E-Mail
 
 To receive notifications by email, the following command-line options, or their corresponding environment variables, can be set:

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ To receive notifications by email, the following command-line options, or their 
 * `--notification-email-from` (env. `WATCHTOWER_NOTIFICATION_EMAIL_FROM`): The e-mail address from which notifications will be sent.
 * `--notification-email-to` (env. `WATCHTOWER_NOTIFICATION_EMAIL_TO`): The e-mail address to which notifications will be sent.
 * `--notification-email-server` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER`): The SMTP server to send e-mails through.
+* `--notification-email-server-tls-skip-verify` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY`): Do not verify the TLS certificate of the mail server. This should be used only for testing.
 * `--notification-email-server-port` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT`): The port used to connect to the SMTP server to send e-mails through. Defaults to `25`.
 * `--notification-email-server-user` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER`): The username to authenticate with the SMTP server with.
 * `--notification-email-server-password` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD`): The password to authenticate with the SMTP server with.

--- a/README.md
+++ b/README.md
@@ -189,9 +189,11 @@ Watchtower can send notifications when containers are updated. Notifications are
 The types of notifications to send are passed via the comma-separated option `--notifications` (or corresponding environment variable `WATCHTOWER_NOTIFICATIONS`), which has the following valid values:
 
 * `email` to send notifications via e-mail
+* `slack` to send notifications through a Slack webhook
 * `discord` to send notifications into Discord channel
 
-### Email
+### Notifications via E-Mail
+
 To receive notifications by email, the following command-line options, or their corresponding environment variables, can be set:
 
 * `--notification-email-from` (env. `WATCHTOWER_NOTIFICATION_EMAIL_FROM`): The e-mail address from which notifications will be sent.
@@ -217,7 +219,28 @@ docker run -d \
   v2tec/watchtower
 ```
 
-### Discord
+### Notifications through Slack webhook
+
+To receive notifications in Slack, add `slack` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
+
+Additionally, you should set the Slack webhook url using the `--notification-slack-hook-url` option or the `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL` environment variable.
+
+By default, watchtower will send messages under the name `watchtower`, you can customize this string through the `--notification-slack-identifier` option or the `WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER` environment variable.
+
+Example:
+
+```bash
+docker run -d \
+  --name watchtower \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WATCHTOWER_NOTIFICATIONS=slack \
+  -e WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL="https://hooks.slack.com/services/xxx/yyyyyyyyyyyyyyy" \
+  -e WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER=watchtower-server-1 \
+  v2tec/watchtower
+```
+
+### Notifications via Discord webhook
+
 To send notifications into Discord channel, the following command-line options, or their corresponding environment variables, can be set:
 
 * `--notification-discord-webhook` (env. `WATCHTOWER_NOTIFICATION_DISCORD_WEBHOOK`): Webhook URL configured in Discord.

--- a/actions/update.go
+++ b/actions/update.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/v2tec/watchtower/container"
 )
 

--- a/actions/update.go
+++ b/actions/update.go
@@ -45,8 +45,7 @@ func Update(client container.Client, names []string, cleanup bool, noRestart boo
 	for i, container := range containers {
 		stale, err := client.IsContainerStale(container)
 		if err != nil {
-			log.Infof("Unable to update container %s. Proceeding to next.", containers[i].Name())
-			log.Debug(err)
+			log.Infof("Unable to update container %s, err='%s'. Proceeding to next.", containers[i].Name(), err)
 			stale = false
 		}
 		containers[i].Stale = stale

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: v2tec/gobuilder:0.2.0_go1.7.4-glide0.12.3-goreleaser0.40.3-docker17.03.0
+      - image: v2tec/gobuilder:0.5.0_go1.7.4-glide0.12.3-goreleaser0.59.0-docker17.05.0
     working_directory: /src
     steps:
       - checkout
       - setup_remote_docker:
-          version: 17.03.0-ce
+          version: 17.05.0-ce
       - run: git fetch --tags
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/container/client.go
+++ b/container/client.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	dockerclient "github.com/docker/docker/client"

--- a/container/trust.go
+++ b/container/trust.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/reference"
 	"github.com/docker/docker/cli/command"

--- a/dockerfile/amd64/Dockerfile
+++ b/dockerfile/amd64/Dockerfile
@@ -1,4 +1,20 @@
-FROM centurylink/ca-certs
+#
+# Alpine image to get some needed data
+#
+FROM alpine:latest as alpine
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata
+
+#
+# Image
+#
+FROM scratch
 LABEL "com.centurylinklabs.watchtower"="true"
+
+# copy files from other containers
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=alpine /usr/share/zoneinfo /usr/share/zoneinfo
+
 COPY watchtower /
 ENTRYPOINT ["/watchtower"]

--- a/dockerfile/armhf/Dockerfile
+++ b/dockerfile/armhf/Dockerfile
@@ -1,4 +1,20 @@
-FROM centurylink/ca-certs
+#
+# Alpine image to get some needed data
+#
+FROM alpine:latest as alpine
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata
+
+#
+# Image
+#
+FROM scratch
 LABEL "com.centurylinklabs.watchtower"="true"
+
+# copy files from other containers
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=alpine /usr/share/zoneinfo /usr/share/zoneinfo
+
 COPY watchtower /
 ENTRYPOINT ["/watchtower"]

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9ddd729b207d71ce16ae9a0282ac87a046b9161ac4f15b108e86a03367172516
-updated: 2017-01-24T20:45:43.1914053+01:00
+hash: c0e0c69383b9b665e92c40a5ea69632ea846a645f44654411137c75c5ef5017c
+updated: 2017-11-27T11:34:21.283697431+01:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 388960b655244e76e24c75f48631564eaefade62
@@ -25,7 +25,7 @@ imports:
   - registry/storage/cache/memory
   - uuid
 - name: github.com/docker/docker
-  version: 49bf474f9ed7ce7143a59d1964ff7b7fd9b52178
+  version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
   subpackages:
   - api
   - api/server/httputils
@@ -110,13 +110,16 @@ imports:
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/johntdyer/slack-go
+  version: 88ef3038545fa084d81f36e4a6943d112cdd74f6
+- name: github.com/johntdyer/slackrus
+  version: 3992f319fd0ac349483279ef74742cd787841cba
 - name: github.com/mattn/go-shellwords
   version: f4e566c536cf69158e808ec28ef4182a37fdc981
 - name: github.com/Microsoft/go-winio
   version: 24a3e3d3fc7451805e09d11e11e95d9a0a4f205e
 - name: github.com/opencontainers/runc
-  version: 2f7393a47307a16f8cee44a37b262e8b81021e3e
-  repo: https://github.com/docker/runc.git
+  version: e8149af2910850602cae998dede29e630d1b8ee1
   subpackages:
   - libcontainer/configs
   - libcontainer/devices
@@ -135,10 +138,11 @@ imports:
 - name: github.com/robfig/cron
   version: 9585fd555638e77bba25f25db5c44b41f264aeb7
 - name: github.com/Sirupsen/logrus
-  version: d26492970760ca5d33129d2d799e34be5c4782eb
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/cobra
-  version: a3c09249f1a24a9d951f2738fb9b9256b8b42fa5
-  repo: https://github.com/dnephin/cobra.git
+  version: 1be1d2841c773c01bee8289f55f7463b6e2c2539
 - name: github.com/spf13/pflag
   version: dabebe21bf790f782ea4c7bbd2efc430de182afd
 - name: github.com/stretchr/objx

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c0e0c69383b9b665e92c40a5ea69632ea846a645f44654411137c75c5ef5017c
-updated: 2017-11-27T11:34:21.283697431+01:00
+hash: 23bcd62f9352c61d3aebc85a59f7ebbfaf80bc0201f45037cdea65820673ddeb
+updated: 2018-03-01T13:21:55.8472118+01:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 388960b655244e76e24c75f48631564eaefade62
@@ -91,7 +91,7 @@ imports:
   - client
   - credentials
 - name: github.com/docker/go-connections
-  version: 4ccf312bf1d35e5dbda654e57a9be4c3f3cd0366
+  version: ecb4cb2dd420ada7df7f2593d6c25441f65f69f2
   subpackages:
   - nat
   - sockets
@@ -111,15 +111,16 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/johntdyer/slack-go
-  version: 88ef3038545fa084d81f36e4a6943d112cdd74f6
+  version: 95fac1160b220c5abcf8b0ef88e9c3cb213c09f4
 - name: github.com/johntdyer/slackrus
   version: 3992f319fd0ac349483279ef74742cd787841cba
 - name: github.com/mattn/go-shellwords
   version: f4e566c536cf69158e808ec28ef4182a37fdc981
 - name: github.com/Microsoft/go-winio
-  version: 24a3e3d3fc7451805e09d11e11e95d9a0a4f205e
+  version: fff283ad5116362ca252298cfc9b95828956d85d
 - name: github.com/opencontainers/runc
-  version: e8149af2910850602cae998dede29e630d1b8ee1
+  version: 9df8b306d01f59d3a8029be411de015b7304dd8f
+  repo: https://github.com/docker/runc.git
   subpackages:
   - libcontainer/configs
   - libcontainer/devices
@@ -139,10 +140,12 @@ imports:
   version: 9585fd555638e77bba25f25db5c44b41f264aeb7
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  repo: https://github.com/sirupsen/logrus.git
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/cobra
-  version: 1be1d2841c773c01bee8289f55f7463b6e2c2539
+  version: a3c09249f1a24a9d951f2738fb9b9256b8b42fa5
+  repo: https://github.com/dnephin/cobra.git
 - name: github.com/spf13/pflag
   version: dabebe21bf790f782ea4c7bbd2efc430de182afd
 - name: github.com/stretchr/objx

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/v2tec/watchtower
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ~0.11.x
 - package: github.com/docker/docker
   version: ~1.13.x

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,3 +26,5 @@ import:
   - context
 - package: github.com/robfig/cron
   version: 9585fd555638e77bba25f25db5c44b41f264aeb7
+- package: github.com/johntdyer/slackrus
+  version: 3992f31

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,9 @@ package: github.com/v2tec/watchtower
 import:
 - package: github.com/sirupsen/logrus
   version: ~0.11.x
+- package: github.com/Sirupsen/logrus
+  repo: https://github.com/sirupsen/logrus.git
+  version: ~0.11.x
 - package: github.com/docker/docker
   version: ~1.13.x
   subpackages:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -58,7 +58,8 @@ dockers:
     binary: watchtower
     image: v2tec/watchtower
     dockerfile: dockerfile/amd64/Dockerfile
-    tag_template: "{{ .Version }}"
+    tag_templates:
+      - '{{ .Version }}'
   -
     goos: linux
     goarch: arm
@@ -66,4 +67,5 @@ dockers:
     binary: watchtower
     image: v2tec/watchtower
     dockerfile: dockerfile/armhf/Dockerfile
-    tag_template: "armhf-{{ .Version }}"
+    tag_templates:
+      - 'armhf-{{ .Version }}'

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/robfig/cron"
 	"github.com/urfave/cli"
 	"github.com/v2tec/watchtower/actions"

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/robfig/cron"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/v2tec/watchtower/actions"
 	"github.com/v2tec/watchtower/container"
@@ -135,6 +135,23 @@ func main() {
 			Name:   "notification-email-server-password",
 			Usage:  "SMTP server password for sending notifications",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD",
+		},
+		cli.StringFlag{
+			Name:   "notification-slack-hook-url",
+			Usage:  "The Slack Hook URL to send notifications to",
+			EnvVar: "WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL",
+		},
+		cli.StringFlag{
+			Name:   "notification-slack-identifier",
+			Usage:  "A string which will be used to identify the messages coming from this watchtower instance. Default if omitted is \"watchtower\"",
+			EnvVar: "WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER",
+			Value:  "watchtower",
+		},
+		cli.StringFlag{
+			Name:   "notification-slack-level",
+			Usage:  "The log level used for sending notifications through Slack. Default if omitted is \"info\". Possible values: \"panic\",\"fatal\",\"error\",\"warn\",\"info\" or \"debug\"",
+			EnvVar: "WATCHTOWER_NOTIFICATION_SLACK_LEVEL",
+			Value:  "info",
 		},
 		cli.StringFlag{
 			Name:   "notification-discord-webhook",

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		cli.StringSliceFlag{
 			Name:   "notifications",
 			Value:  &cli.StringSlice{},
-			Usage:  "notification types to send (valid: email, discord)",
+			Usage:  "notification types to send (valid: email, slack, discord)",
 			EnvVar: "WATCHTOWER_NOTIFICATIONS",
 		},
 		cli.StringFlag{
@@ -116,6 +116,15 @@ func main() {
 			Usage:  "SMTP server port to send notification e-mails through",
 			Value:  25,
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT",
+		},
+		cli.BoolFlag{
+			Name: "notification-email-server-tls-skip-verify",
+			Usage: "Controls whether watchtower verifies the SMTP server's certificate chain and host name. " +
+				"If set, TLS accepts any certificate " +
+				"presented by the server and any host name in that certificate. " +
+				"In this mode, TLS is susceptible to man-in-the-middle attacks. " +
+				"This should be used only for testing.",
+			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY",
 		},
 		cli.StringFlag{
 			Name:   "notification-email-server-user",

--- a/main.go
+++ b/main.go
@@ -91,41 +91,46 @@ func main() {
 			Usage: "enable debug mode with verbose logging",
 		},
 		cli.StringSliceFlag{
-			Name: "notifications",
-			Value: &cli.StringSlice{},
-			Usage: "notification types to send (valid: email)",
+			Name:   "notifications",
+			Value:  &cli.StringSlice{},
+			Usage:  "notification types to send (valid: email, discord)",
 			EnvVar: "WATCHTOWER_NOTIFICATIONS",
 		},
 		cli.StringFlag{
-			Name: "notification-email-from",
-			Usage: "Address to send notification e-mails from",
+			Name:   "notification-email-from",
+			Usage:  "Address to send notification e-mails from",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_FROM",
 		},
 		cli.StringFlag{
-			Name: "notification-email-to",
-			Usage: "Address to send notification e-mails to",
+			Name:   "notification-email-to",
+			Usage:  "Address to send notification e-mails to",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_TO",
 		},
 		cli.StringFlag{
-			Name: "notification-email-server",
-			Usage: "SMTP server to send notification e-mails through",
+			Name:   "notification-email-server",
+			Usage:  "SMTP server to send notification e-mails through",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER",
 		},
 		cli.IntFlag{
-			Name: "notification-email-server-port",
-			Usage: "SMTP server port to send notification e-mails through",
+			Name:   "notification-email-server-port",
+			Usage:  "SMTP server port to send notification e-mails through",
 			Value:  25,
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT",
 		},
 		cli.StringFlag{
-			Name: "notification-email-server-user",
-			Usage: "SMTP server user for sending notifications",
+			Name:   "notification-email-server-user",
+			Usage:  "SMTP server user for sending notifications",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER",
 		},
 		cli.StringFlag{
-			Name: "notification-email-server-password",
-			Usage: "SMTP server password for sending notifications",
+			Name:   "notification-email-server-password",
+			Usage:  "SMTP server password for sending notifications",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD",
+		},
+		cli.StringFlag{
+			Name:   "notification-discord-webhook",
+			Usage:  "Discord webhook url for sending notifications",
+			EnvVar: "WATCHTOWER_NOTIFICATION_DISCORD_WEBHOOK",
 		},
 	}
 
@@ -180,7 +185,7 @@ func start(c *cli.Context) error {
 		scheduleSpec,
 		func() {
 			select {
-			case v := <- tryLockSem:
+			case v := <-tryLockSem:
 				defer func() { tryLockSem <- v }()
 				notifier.StartNotification()
 				if err := actions.Update(client, names, cleanup, noRestart); err != nil {

--- a/main.go
+++ b/main.go
@@ -97,6 +97,12 @@ func main() {
 			EnvVar: "WATCHTOWER_NOTIFICATIONS",
 		},
 		cli.StringFlag{
+			Name:   "notifications-level",
+			Usage:  "The log level used for sending notifications. Possible values: \"panic\", \"fatal\", \"error\", \"warn\", \"info\" or \"debug\"",
+			EnvVar: "WATCHTOWER_NOTIFICATIONS_LEVEL",
+			Value:  "info",
+		},
+		cli.StringFlag{
 			Name:   "notification-email-from",
 			Usage:  "Address to send notification e-mails from",
 			EnvVar: "WATCHTOWER_NOTIFICATION_EMAIL_FROM",
@@ -146,12 +152,6 @@ func main() {
 			Usage:  "A string which will be used to identify the messages coming from this watchtower instance. Default if omitted is \"watchtower\"",
 			EnvVar: "WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER",
 			Value:  "watchtower",
-		},
-		cli.StringFlag{
-			Name:   "notification-slack-level",
-			Usage:  "The log level used for sending notifications through Slack. Default if omitted is \"info\". Possible values: \"panic\",\"fatal\",\"error\",\"warn\",\"info\" or \"debug\"",
-			EnvVar: "WATCHTOWER_NOTIFICATION_SLACK_LEVEL",
-			Value:  "info",
 		},
 		cli.StringFlag{
 			Name:   "notification-discord-webhook",

--- a/notifications/discord.go
+++ b/notifications/discord.go
@@ -1,0 +1,96 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+const (
+	discordType = "discord"
+)
+
+type discordTypeNotifier struct {
+	WebhookURL string
+	entries    []*log.Entry
+}
+
+func newDiscordNotifier(c *cli.Context) typeNotifier {
+	n := &discordTypeNotifier{
+		WebhookURL: c.GlobalString("notification-discord-webhook"),
+	}
+
+	log.AddHook(n)
+
+	return n
+}
+
+func (n *discordTypeNotifier) sendEntries(entries []*log.Entry) {
+	// Do the sending in a separate goroutine so we don't block the main process.
+	message := ""
+	for _, entry := range entries {
+		message += entry.Time.Format("2006-01-02 15:04:05") + " (" + entry.Level.String() + "): " + entry.Message + "\r\n"
+	}
+
+	go func() {
+		webhookBody := discordWebhookBody{Content: message}
+		jsonBody, err := json.Marshal(webhookBody)
+		if err != nil {
+			fmt.Println("Failed to build JSON body for Discord notificattion: ", err)
+			return
+		}
+
+		resp, err := http.Post(n.WebhookURL, "application/json", bytes.NewBuffer([]byte(jsonBody)))
+		if err != nil {
+			fmt.Println("Failed to send Discord notificattion: ", err)
+		}
+
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			fmt.Println("Failed to send Discord notificattion. HTTP RESPONSE STATUS: ", resp.StatusCode)
+		}
+	}()
+}
+
+func (n *discordTypeNotifier) StartNotification() {
+	if n.entries == nil {
+		n.entries = make([]*log.Entry, 0, 10)
+	}
+}
+
+func (n *discordTypeNotifier) SendNotification() {
+	if n.entries != nil && len(n.entries) != 0 {
+		n.sendEntries(n.entries)
+	}
+	n.entries = nil
+}
+
+func (n *discordTypeNotifier) Levels() []log.Level {
+	// TODO: Make this configurable.
+	return []log.Level{
+		log.PanicLevel,
+		log.FatalLevel,
+		log.ErrorLevel,
+		log.WarnLevel,
+		log.InfoLevel,
+	}
+}
+
+func (n *discordTypeNotifier) Fire(entry *log.Entry) error {
+	if n.entries != nil {
+		n.entries = append(n.entries, entry)
+	} else {
+		// Log output generated outside a cycle is sent immediately.
+		n.sendEntries([]*log.Entry{entry})
+	}
+	return nil
+}
+
+type discordWebhookBody struct {
+	Content string `json:"content"`
+}

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -81,7 +81,10 @@ func (e *emailTypeNotifier) sendEntries(entries []*log.Entry) {
 	// Do the sending in a separate goroutine so we don't block the main process.
 	msg := e.buildMessage(entries)
 	go func() {
-		auth := smtp.PlainAuth("", e.User, e.Password, e.Server)
+		var auth smtp.Auth
+		if e.User != "" {
+			auth = smtp.PlainAuth("", e.User, e.Password, e.Server)
+		}
 		err := SendMail(e.Server+":"+strconv.Itoa(e.Port), e.tlsSkipVerify, auth, e.From, []string{e.To}, msg)
 		if err != nil {
 			// Use fmt so it doesn't trigger another email.

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/smtp"
 	"os"
+	"time"
 
 	"strconv"
 
@@ -54,10 +55,13 @@ func (e *emailTypeNotifier) buildMessage(entries []*log.Entry) []byte {
 		// We don't use fields in watchtower, so don't bother sending them.
 	}
 
+	t := time.Now()
+	
 	header := make(map[string]string)
 	header["From"] = e.From
 	header["To"] = e.To
 	header["Subject"] = emailSubject
+	header["Date"] = t.Format(time.RFC1123)
 	header["MIME-Version"] = "1.0"
 	header["Content-Type"] = "text/plain; charset=\"utf-8\""
 	header["Content-Transfer-Encoding"] = "base64"

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -61,7 +61,7 @@ func (e *emailTypeNotifier) buildMessage(entries []*log.Entry) []byte {
 	header["From"] = e.From
 	header["To"] = e.To
 	header["Subject"] = emailSubject
-	header["Date"] = t.Format(time.RFC1123)
+	header["Date"] = t.Format(time.RFC1123Z)
 	header["MIME-Version"] = "1.0"
 	header["Content-Type"] = "text/plain; charset=\"utf-8\""
 	header["Content-Transfer-Encoding"] = "base64"

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -72,7 +72,12 @@ func (e *emailTypeNotifier) buildMessage(entries []*log.Entry) []byte {
 	for k, v := range header {
 		message += fmt.Sprintf("%s: %s\r\n", k, v)
 	}
-	message += "\r\n" + base64.StdEncoding.EncodeToString([]byte(body))
+
+	encodedBody := base64.StdEncoding.EncodeToString([]byte(body))
+	//RFC 2045 base64 encoding demands line no longer than 76 characters.
+	for _, line := range SplitSubN(encodedBody, 76) {
+		message += "\r\n" + line
+	}
 
 	return []byte(message)
 }

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -28,9 +28,10 @@ type emailTypeNotifier struct {
 	Port                   int
 	tlsSkipVerify          bool
 	entries                []*log.Entry
+	logLevels              []log.Level
 }
 
-func newEmailNotifier(c *cli.Context) typeNotifier {
+func newEmailNotifier(c *cli.Context, acceptedLogLevels []log.Level) typeNotifier {
 	n := &emailTypeNotifier{
 		From:          c.GlobalString("notification-email-from"),
 		To:            c.GlobalString("notification-email-to"),
@@ -39,6 +40,7 @@ func newEmailNotifier(c *cli.Context) typeNotifier {
 		Password:      c.GlobalString("notification-email-server-password"),
 		Port:          c.GlobalInt("notification-email-server-port"),
 		tlsSkipVerify: c.GlobalBool("notification-email-server-tls-skip-verify"),
+		logLevels:     acceptedLogLevels,
 	}
 
 	log.AddHook(n)
@@ -112,14 +114,7 @@ func (e *emailTypeNotifier) SendNotification() {
 }
 
 func (e *emailTypeNotifier) Levels() []log.Level {
-	// TODO: Make this configurable.
-	return []log.Level{
-		log.PanicLevel,
-		log.FatalLevel,
-		log.ErrorLevel,
-		log.WarnLevel,
-		log.InfoLevel,
-	}
+	return e.logLevels
 }
 
 func (e *emailTypeNotifier) Fire(entry *log.Entry) error {

--- a/notifications/email.go
+++ b/notifications/email.go
@@ -9,7 +9,7 @@ import (
 
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/notifications/notifier.go
+++ b/notifications/notifier.go
@@ -1,7 +1,7 @@
 package notifications
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/notifications/notifier.go
+++ b/notifications/notifier.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"github.com/johntdyer/slackrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -19,17 +20,24 @@ type Notifier struct {
 func NewNotifier(c *cli.Context) *Notifier {
 	n := &Notifier{}
 
+	logLevel, err := log.ParseLevel(c.GlobalString("notifications-level"))
+	if err != nil {
+		log.Fatalf("Notifications invalid log level: %s", err.Error())
+	}
+
+	acceptedLogLevels := slackrus.LevelThreshold(logLevel)
+
 	// Parse types and create notifiers.
 	types := c.GlobalStringSlice("notifications")
 	for _, t := range types {
 		var tn typeNotifier
 		switch t {
 		case emailType:
-			tn = newEmailNotifier(c)
+			tn = newEmailNotifier(c, acceptedLogLevels)
 		case slackType:
-			tn = newSlackNotifier(c)
+			tn = newSlackNotifier(c, acceptedLogLevels)
 		case discordType:
-			tn = newDiscordNotifier(c)
+			tn = newDiscordNotifier(c, acceptedLogLevels)
 		default:
 			log.Fatalf("Unknown notification type %q", t)
 		}

--- a/notifications/notifier.go
+++ b/notifications/notifier.go
@@ -26,6 +26,8 @@ func NewNotifier(c *cli.Context) *Notifier {
 		switch t {
 		case emailType:
 			tn = newEmailNotifier(c)
+		case slackType:
+			tn = newSlackNotifier(c)
 		case discordType:
 			tn = newDiscordNotifier(c)
 		default:

--- a/notifications/notifier.go
+++ b/notifications/notifier.go
@@ -26,6 +26,8 @@ func NewNotifier(c *cli.Context) *Notifier {
 		switch t {
 		case emailType:
 			tn = newEmailNotifier(c)
+		case discordType:
+			tn = newDiscordNotifier(c)
 		default:
 			log.Fatalf("Unknown notification type %q", t)
 		}

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -1,0 +1,38 @@
+package notifications
+
+import (
+	"github.com/johntdyer/slackrus"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+const (
+	slackType = "slack"
+)
+
+type slackTypeNotifier struct {
+	slackrus.SlackrusHook
+}
+
+func newSlackNotifier(c *cli.Context) typeNotifier {
+	logLevel, err := log.ParseLevel(c.GlobalString("notification-slack-level"))
+	if err != nil {
+		log.Fatalf("Slack notifications: %s", err.Error())
+	}
+
+	n := &slackTypeNotifier{
+		SlackrusHook: slackrus.SlackrusHook{
+			HookURL:        c.GlobalString("notification-slack-hook-url"),
+			Username:       c.GlobalString("notification-slack-identifier"),
+			AcceptedLevels: slackrus.LevelThreshold(logLevel),
+		},
+	}
+
+	log.AddHook(n)
+
+	return n
+}
+
+func (s *slackTypeNotifier) StartNotification() {}
+
+func (s *slackTypeNotifier) SendNotification() {}

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -14,17 +14,12 @@ type slackTypeNotifier struct {
 	slackrus.SlackrusHook
 }
 
-func newSlackNotifier(c *cli.Context) typeNotifier {
-	logLevel, err := log.ParseLevel(c.GlobalString("notification-slack-level"))
-	if err != nil {
-		log.Fatalf("Slack notifications: %s", err.Error())
-	}
-
+func newSlackNotifier(c *cli.Context, acceptedLogLevels []log.Level) typeNotifier {
 	n := &slackTypeNotifier{
 		SlackrusHook: slackrus.SlackrusHook{
 			HookURL:        c.GlobalString("notification-slack-hook-url"),
 			Username:       c.GlobalString("notification-slack-identifier"),
-			AcceptedLevels: slackrus.LevelThreshold(logLevel),
+			AcceptedLevels: acceptedLogLevels,
 		},
 	}
 

--- a/notifications/smtp.go
+++ b/notifications/smtp.go
@@ -1,0 +1,76 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license.
+package notifications
+
+import (
+	"crypto/tls"
+	"net"
+	"net/smtp"
+)
+
+// SendMail connects to the server at addr, switches to TLS if
+// possible, authenticates with the optional mechanism a if possible,
+// and then sends an email from address from, to addresses to, with
+// message msg.
+// The addr must include a port, as in "mail.example.com:smtp".
+//
+// The addresses in the to parameter are the SMTP RCPT addresses.
+//
+// The msg parameter should be an RFC 822-style email with headers
+// first, a blank line, and then the message body. The lines of msg
+// should be CRLF terminated. The msg headers should usually include
+// fields such as "From", "To", "Subject", and "Cc".  Sending "Bcc"
+// messages is accomplished by including an email address in the to
+// parameter but not including it in the msg headers.
+//
+// The SendMail function and the net/smtp package are low-level
+// mechanisms and provide no support for DKIM signing, MIME
+// attachments (see the mime/multipart package), or other mail
+// functionality. Higher-level packages exist outside of the standard
+// library.
+func SendMail(addr string, insecureSkipVerify bool, a smtp.Auth, from string, to []string, msg []byte) error {
+	c, err := smtp.Dial(addr)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	if err = c.Hello("localHost"); err != nil {
+		return err
+	}
+	if ok, _ := c.Extension("STARTTLS"); ok {
+		serverName, _, _ := net.SplitHostPort(addr)
+		config := &tls.Config{ServerName: serverName, InsecureSkipVerify: insecureSkipVerify}
+		if err = c.StartTLS(config); err != nil {
+			return err
+		}
+	}
+	if a != nil {
+		if ok, _ := c.Extension("AUTH"); ok {
+			if err = c.Auth(a); err != nil {
+				return err
+			}
+		}
+	}
+	if err = c.Mail(from); err != nil {
+		return err
+	}
+	for _, addr := range to {
+		if err = c.Rcpt(addr); err != nil {
+			return err
+		}
+	}
+	w, err := c.Data()
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(msg)
+	if err != nil {
+		return err
+	}
+	err = w.Close()
+	if err != nil {
+		return err
+	}
+	return c.Quit()
+}

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -1,0 +1,24 @@
+package notifications
+
+import "bytes"
+
+// SplitSubN splits a string into a list of string with each having
+// a maximum number of characters n
+func SplitSubN(s string, n int) []string {
+	sub := ""
+	subs := []string{}
+
+	runes := bytes.Runes([]byte(s))
+	l := len(runes)
+	for i, r := range runes {
+		sub = sub + string(r)
+		if (i+1)%n == 0 {
+			subs = append(subs, sub)
+			sub = ""
+		} else if (i + 1) == l {
+			subs = append(subs, sub)
+		}
+	}
+
+	return subs
+}


### PR DESCRIPTION
Send notifications into Discord channel with webhook url.
Part from README.md:

## Notifications
....
* `discord` to send notifications into Discord channel

### Discord
To send notifications into Discord channel, the following command-line options, or their corresponding environment variables, can be set:

* `--notification-discord-webhook` (env. `WATCHTOWER_NOTIFICATION_DISCORD_WEBHOOK`): Webhook URL configured in Discord.

[Checkout how to add webhook for channel](https://support.discordapp.com/hc/en-us/articles/228383668)