### PR TITLE
Add Dockerfile.self-contained

### DIFF
--- a/Dockerfile.multistage-build
+++ b/Dockerfile.multistage-build
@@ -1,0 +1,39 @@
+#
+# Builder
+#
+
+FROM golang:alpine as builder
+
+# use version (for example "v0.3.3") or "master"
+ARG WATCHTOWER_VERSION=master
+
+RUN \
+  apk add --no-cache \
+    alpine-sdk \
+    ca-certificates \
+    git \
+    tzdata && \
+  \
+  mkdir --parents $GOPATH/src/github.com/containrrr && \
+  cd $GOPATH/src/github.com/containrrr && \
+  git clone --branch "${WATCHTOWER_VERSION}" https://github.com/containrrr/watchtower.git && \
+  cd watchtower && \
+  \
+  GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' . && \
+  GO111MODULE=on go test ./... -v
+
+
+#
+# watchtower
+#
+
+FROM scratch
+
+LABEL "com.centurylinklabs.watchtower"="true"
+
+# copy files from other container
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /go/src/github.com/containrrr/watchtower/watchtower /watchtower
+
+ENTRYPOINT ["/watchtower"]

--- a/Dockerfile.self-contained
+++ b/Dockerfile.self-contained
@@ -7,16 +7,15 @@ FROM golang:alpine as builder
 # use version (for example "v0.3.3") or "master"
 ARG WATCHTOWER_VERSION=master
 
-RUN \
-  apk add --no-cache \
+RUN apk add --no-cache \
     alpine-sdk \
     ca-certificates \
     git \
-    tzdata && \
-  \
-  mkdir --parents $GOPATH/src/github.com/containrrr && \
-  cd $GOPATH/src/github.com/containrrr && \
-  git clone --branch "${WATCHTOWER_VERSION}" https://github.com/containrrr/watchtower.git && \
+    tzdata
+
+RUN git clone --branch "${WATCHTOWER_VERSION}" https://github.com/containrrr/watchtower.git
+
+RUN \
   cd watchtower && \
   \
   GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' . && \
@@ -34,6 +33,6 @@ LABEL "com.centurylinklabs.watchtower"="true"
 # copy files from other container
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=builder /go/src/github.com/containrrr/watchtower/watchtower /watchtower
+COPY --from=builder /go/watchtower/watchtower /watchtower
 
 ENTRYPOINT ["/watchtower"]


### PR DESCRIPTION
This pull request adds an alternative dockerfile that uses docker's multistage build feature to build watchtower in a container and not on the host system. 

I've been using a very similar docker file for a while to build [svengo/watchtower](https://hub.docker.com/r/svengo/watchtower). Maybe someone else will find that useful, too. See also [#281](https://github.com/containrrr/watchtower/issues/281#issuecomment-484467347).