### PR TITLE
Make it possible to use watchtower to update exited or created containers as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ docker run --rm containrrr/watchtower --help
 - `--tlsverify` Use TLS when connecting to the Docker socket and verify the server's certificate.
 - `--debug` Enable debug mode. When this option is specified you'll see more verbose logging in the watchtower log file.
 - `--monitor-only` Will only monitor for new images, not update the containers.
+- `--include-stopped` Will also include created and exited containers.
 - `--help` Show documentation about the supported flags.
 
 See below for options used to configure notifications.

--- a/app/app.go
+++ b/app/app.go
@@ -155,8 +155,14 @@ func SetupCliFlags(app *cli.App) {
 			EnvVar: "WATCHTOWER_MONITOR_ONLY",
 		},
 		cli.BoolFlag{
-			Name:  "run-once",
-			Usage: "Run once now and exit",
+			Name:   "run-once",
+			Usage:  "Run once now and exit",
+			EnvVar: "WATCHTOWER_RUN_ONCE",
+		},
+		cli.BoolFlag{
+			Name:   "include-stopped",
+			Usage:  "Will also include stopped or exited containers",
+			EnvVar: "WATCHTOWER_INCLUDE_STOPPED",
 		},
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -161,7 +161,7 @@ func SetupCliFlags(app *cli.App) {
 		},
 		cli.BoolFlag{
 			Name:   "include-stopped",
-			Usage:  "Will also include stopped or exited containers",
+			Usage:  "Will also include created and exited containers",
 			EnvVar: "WATCHTOWER_INCLUDE_STOPPED",
 		},
 	}

--- a/container/client.go
+++ b/container/client.go
@@ -189,11 +189,11 @@ func (client dockerClient) StartContainer(c Container) error {
 
 	}
 
-	return client.startContainerIfPreviouslyRunning(c, creation, bg)
+	return client.startContainerIfPreviouslyRunning(bg, c, creation)
 
 }
 
-func (client dockerClient) startContainerIfPreviouslyRunning(c Container, creation container.ContainerCreateCreatedBody, bg context.Context) error {
+func (client dockerClient) startContainerIfPreviouslyRunning(bg context.Context, c Container, creation container.ContainerCreateCreatedBody) error {
 	name := c.Name()
 
 	if !c.IsRunning() {

--- a/container/client.go
+++ b/container/client.go
@@ -59,8 +59,6 @@ func (client dockerClient) ListContainers(fn Filter) ([]Container, error) {
 	cs := []Container{}
 	bg := context.Background()
 
-	log.Info("include stopped: ", client.includeStopped)
-
 	if client.includeStopped {
 		log.Debug("Retrieving containers including stopped and exited")
 	} else {
@@ -73,7 +71,7 @@ func (client dockerClient) ListContainers(fn Filter) ([]Container, error) {
 		types.ContainerListOptions{
 			Filters: filter,
 		})
-	log.Info(containers)
+	
 	if err != nil {
 		return nil, err
 	}

--- a/container/container.go
+++ b/container/container.go
@@ -38,6 +38,13 @@ func (c Container) ID() string {
 	return c.containerInfo.ID
 }
 
+// IsRunning returns a boolean flag indicating whether or not the current
+// container is running. The status is determined by the value of the
+// container's "State.Running" property.
+func (c Container) IsRunning() bool {
+	return c.containerInfo.State.Running
+}
+
 // Name returns the Docker container name.
 func (c Container) Name() string {
 	return c.containerInfo.Name

--- a/container/mocks/ApiServer.go
+++ b/container/mocks/ApiServer.go
@@ -18,7 +18,11 @@ func NewMockAPIServer() *httptest.Server {
 			logrus.Debug("Mock server has received a HTTP call on ", r.URL)
 			var response = ""
 
-			if  isRequestFor("containers/json?limit=0", r) {
+			if isRequestFor("filters=%7B%22status%22%3A%7B%22running%22%3Atrue%7D%7D&limit=0", r) {
+				response = getMockJSONFromDisk("./mocks/data/containers.json")
+			} else if isRequestFor("filters=%7B%22status%22%3A%7B%22created%22%3Atrue%2C%22exited%22%3Atrue%2C%22running%22%3Atrue%7D%7D&limit=0", r) {
+				response = getMockJSONFromDisk("./mocks/data/containers.json")
+			} else if isRequestFor("containers/json?limit=0", r) {
 				response = getMockJSONFromDisk("./mocks/data/containers.json")
 			} else if isRequestFor("ae8964ba86c7cd7522cf84e09781343d88e0e3543281c747d88b27e246578b65", r) {
 				response = getMockJSONFromDisk("./mocks/data/container_stopped.json")
@@ -48,4 +52,3 @@ func getMockJSONFromDisk(relPath string) string {
 	}
 	return string(buf)
 }
-

--- a/container/mocks/data/containers.json
+++ b/container/mocks/data/containers.json
@@ -12,7 +12,7 @@
     "Labels": {
       "com.centurylinklabs.watchtower": "true"
     },
-    "State": "exited",
+    "State": "running",
     "Status": "Exited (1) 6 days ago",
     "HostConfig": {
       "NetworkMode": "default"

--- a/main.go
+++ b/main.go
@@ -89,7 +89,10 @@ func before(c *cli.Context) error {
 		return err
 	}
 
-	client = container.NewClient(!c.GlobalBool("no-pull"))
+	client = container.NewClient(
+		!c.GlobalBool("no-pull"),
+		c.GlobalBool("include-stopped"),
+	)
 	notifier = notifications.NewNotifier(c)
 
 	return nil


### PR DESCRIPTION
Resolves #112 

Adds the flag `--include-stopped` which, when used, makes watchtower pull images and recreate exited and created containers as well. This feature defaults to disabled. Appropriate tests has been added to `container_test.go`.

Would appreciate if someone other than me tried it out before merging it with master. 🙏 
@KopfKrieg and/or @Codelica, any of you up for the task? 😄 