### PR TITLE
Add docker api version parameter

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,10 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DockerAPIMinVersion is the minimum version of the docker api required to
-// use watchtower
-const DockerAPIMinVersion string = "1.24"
-
 var (
 	client         container.Client
 	scheduleSpec   string
@@ -90,7 +86,7 @@ func PreRun(cmd *cobra.Command, args []string) {
 	lifecycleHooks, _ = f.GetBool("enable-lifecycle-hooks")
 
 	// configure environment vars for client
-	err := flags.EnvConfig(cmd, DockerAPIMinVersion)
+	err := flags.EnvConfig(cmd)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -75,7 +75,17 @@ Docker daemon socket to connect to. Can be pointed at a remote Docker host by sp
 Environment Variable: DOCKER_HOST
                 Type: String
              Default: "unix:///var/run/docker.sock"
-```      
+```
+
+## Docker API version
+The API version to use by the Docker client for connecting to the Docker daemon.
+
+```
+            Argument: --api-version, -a
+Environment Variable: DOCKER_API_VERSION
+                Type: String
+             Default: "1.24"
+```
 
 ## Include stopped
 Will also include created and exited containers.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -78,7 +78,7 @@ Environment Variable: DOCKER_HOST
 ```
 
 ## Docker API version
-The API version to use by the Docker client for connecting to the Docker daemon.
+The API version to use by the Docker client for connecting to the Docker daemon. The minimum supported version is 1.24.
 
 ```
             Argument: --api-version, -a

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1,0 +1,39 @@
+package flags
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvConfig_Defaults(t *testing.T) {
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+
+	err := EnvConfig(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, "unix:///var/run/docker.sock", os.Getenv("DOCKER_HOST"))
+	assert.Equal(t, "", os.Getenv("DOCKER_TLS_VERIFY"))
+	assert.Equal(t, DockerAPIMinVersion, os.Getenv("DOCKER_API_VERSION"))
+}
+
+func TestEnvConfig_Custom(t *testing.T) {
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+
+	err := cmd.ParseFlags([]string{"--host", "some-custom-docker-host", "--tlsverify", "--api-version", "1.99"})
+	require.NoError(t, err)
+
+	err = EnvConfig(cmd)
+	require.NoError(t, err)
+
+	assert.Equal(t, "some-custom-docker-host", os.Getenv("DOCKER_HOST"))
+	assert.Equal(t, "1", os.Getenv("DOCKER_TLS_VERIFY"))
+	assert.Equal(t, "1.99", os.Getenv("DOCKER_API_VERSION"))
+}


### PR DESCRIPTION
This PR adds `--api-version` parameter that allows configuring the `DOCKER_API_VERSION` env var used for configuring the Docker Client.

This allows a more flexible solution for #195.