### PR TITLE
Add lifecycle hooks to documentation nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,5 +19,6 @@ nav:
    - 'Remote hosts': 'remote-hosts.md'
    - 'Secure connections': 'secure-connections.md'
    - 'Stop signals': 'stop-signals.md'
+   - 'Lifecycle hooks': 'lifecycle-hooks.md'
 plugins:
     - search


### PR DESCRIPTION
Add lifecycle hooks to documentation nav, because now it can be found only via search.