### PR TITLE
Add --revive-stopped flag to start stopped containers after an update

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,11 +93,13 @@ func PreRun(cmd *cobra.Command, args []string) {
 
 	noPull, _ := f.GetBool("no-pull")
 	includeStopped, _ := f.GetBool("include-stopped")
+	reviveStopped, _ := f.GetBool("revive-stopped")
 	removeVolumes, _ := f.GetBool("remove-volumes")
 
 	client = container.NewClient(
 		!noPull,
 		includeStopped,
+		reviveStopped,
 		removeVolumes,
 	)
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -97,6 +97,16 @@ Environment Variable: WATCHTOWER_INCLUDE_STOPPED
              Default: false
 ```   
 
+## Revive stopped
+Will also start stopped containers that were updated, if include-stopped is active.
+
+```
+            Argument: --revive-stopped
+Environment Variable: WATCHTOWER_REVIVE_STOPPED
+                Type: Boolean
+             Default: false
+```   
+
 ## Poll interval
 Poll interval (in seconds). This value controls how frequently watchtower will poll for new images.
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -98,7 +98,7 @@ Environment Variable: WATCHTOWER_INCLUDE_STOPPED
 ```   
 
 ## Revive stopped
-Will also start stopped containers that were updated, if include-stopped is active.
+Start any stopped containers that have had their image updated. This argument is only usable with the `--include-stopped` argument.
 
 ```
             Argument: --revive-stopped

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -95,6 +95,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Will also include created and exited containers")
 
 	flags.BoolP(
+		"revive-stopped",
+		"",
+		viper.GetBool("WATCHTOWER_REVIVE_STOPPED"),
+		"Will also start stopped containers that were updated, if include-stopped is active")
+
+	flags.BoolP(
 		"enable-lifecycle-hooks",
 		"",
 		viper.GetBool("WATCHTOWER_LIFECYCLE_HOOKS"),
@@ -128,7 +134,7 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"",
 		viper.GetString("WATCHTOWER_NOTIFICATION_EMAIL_TO"),
 		"Address to send notification emails to")
-	
+
 	flags.IntP(
 		"notification-email-delay",
 		"",

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -38,7 +38,7 @@ type Client interface {
 //  * DOCKER_HOST			the docker-engine host to send api requests to
 //  * DOCKER_TLS_VERIFY		whether to verify tls certificates
 //  * DOCKER_API_VERSION	the minimum docker api version to work with
-func NewClient(pullImages bool, includeStopped bool, removeVolumes bool) Client {
+func NewClient(pullImages bool, includeStopped bool, reviveStopped bool, removeVolumes bool) Client {
 	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv)
 
 	if err != nil {
@@ -50,6 +50,7 @@ func NewClient(pullImages bool, includeStopped bool, removeVolumes bool) Client 
 		pullImages:     pullImages,
 		removeVolumes:  removeVolumes,
 		includeStopped: includeStopped,
+		reviveStopped:  reviveStopped,
 	}
 }
 
@@ -58,6 +59,7 @@ type dockerClient struct {
 	pullImages     bool
 	removeVolumes  bool
 	includeStopped bool
+	reviveStopped  bool
 }
 
 func (client dockerClient) ListContainers(fn t.Filter) ([]Container, error) {
@@ -203,7 +205,7 @@ func (client dockerClient) StartContainer(c Container) (string, error) {
 
 	}
 
-	if !c.IsRunning() {
+	if !c.IsRunning() && !client.reviveStopped {
 		return createdContainer.ID, nil
 	}
 


### PR DESCRIPTION
[Based on comment on #289](https://github.com/containrrr/watchtower/pull/289#issuecomment-550408396)

Add `--revive-stopped` flag to start stopped containers after an update.

@simskij I wanted to write tests, but like the last time, I am not sure how to. My golang knowledge and experience are somewhat restricted :)

I would appreciate if you could help with a test case for this one.

Test are passing 5 out of 5 and 20 out of 20.
```bash
go test ./... -v    
    
?       github.com/containrrr/watchtower        [no test files]
?       github.com/containrrr/watchtower/cmd    [no test files]
=== RUN   TestActions
Running Suite: Actions Suite
============================
Random Seed: 1573120754
Will run 5 of 5 specs

••time="2019-11-07T10:59:17+01:00" level=info msg="Found multiple running watchtower instances. Cleaning up."
•time="2019-11-07T10:59:18+01:00" level=info msg="Found multiple running watchtower instances. Cleaning up."
•time="2019-11-07T10:59:19+01:00" level=info msg="Found multiple running watchtower instances. Cleaning up."
•
Ran 5 of 5 Specs in 5.015 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestActions (5.02s)
PASS
ok      github.com/containrrr/watchtower/internal/actions       5.033s
=== RUN   TestEnvConfig_Defaults
--- PASS: TestEnvConfig_Defaults (0.00s)
=== RUN   TestEnvConfig_Custom
--- PASS: TestEnvConfig_Custom (0.00s)
PASS
ok      github.com/containrrr/watchtower/internal/flags 0.018s
=== RUN   TestSliceEqual_True
--- PASS: TestSliceEqual_True (0.00s)
=== RUN   TestSliceEqual_DifferentLengths
--- PASS: TestSliceEqual_DifferentLengths (0.00s)
=== RUN   TestSliceEqual_DifferentContents
--- PASS: TestSliceEqual_DifferentContents (0.00s)
=== RUN   TestSliceSubtract
--- PASS: TestSliceSubtract (0.00s)
=== RUN   TestStringMapSubtract
--- PASS: TestStringMapSubtract (0.00s)
=== RUN   TestStructMapSubtract
--- PASS: TestStructMapSubtract (0.00s)
PASS
ok      github.com/containrrr/watchtower/internal/util  0.027s
=== RUN   TestContainer
Running Suite: Container Suite
==============================
Random Seed: 1573120754
Will run 20 of 20 specs

••••••••••••••••
Ran 20 of 20 Specs in 0.010 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestContainer (0.01s)
=== RUN   TestWatchtowerContainersFilter
--- PASS: TestWatchtowerContainersFilter (0.00s)
    filters_test.go:17: PASS:   IsWatchtower()
=== RUN   TestNoFilter
--- PASS: TestNoFilter (0.00s)
=== RUN   TestFilterByNames
--- PASS: TestFilterByNames (0.00s)
    filters_test.go:42: PASS:   Name()
    filters_test.go:47: PASS:   Name()
=== RUN   TestFilterByEnableLabel
--- PASS: TestFilterByEnableLabel (0.00s)
    filters_test.go:57: PASS:   Enabled()
    filters_test.go:62: PASS:   Enabled()
    filters_test.go:67: PASS:   Enabled()
=== RUN   TestFilterByDisabledLabel
--- PASS: TestFilterByDisabledLabel (0.00s)
    filters_test.go:77: PASS:   Enabled()
    filters_test.go:82: PASS:   Enabled()
    filters_test.go:87: PASS:   Enabled()
=== RUN   TestBuildFilter
--- PASS: TestBuildFilter (0.00s)
    filters_test.go:100: PASS:  Name()
    filters_test.go:100: PASS:  Enabled()
    filters_test.go:106: PASS:  Name()
    filters_test.go:106: PASS:  Enabled()
    filters_test.go:112: PASS:  Name()
    filters_test.go:112: PASS:  Enabled()
    filters_test.go:118: PASS:  Name()
    filters_test.go:118: PASS:  Enabled()
    filters_test.go:123: PASS:  Enabled()
=== RUN   TestBuildFilterEnableLabel
--- PASS: TestBuildFilterEnableLabel (0.00s)
    filters_test.go:135: PASS:  Enabled()
    filters_test.go:141: PASS:  Name()
    filters_test.go:141: PASS:  Enabled()
    filters_test.go:147: PASS:  Name()
    filters_test.go:147: PASS:  Enabled()
    filters_test.go:152: PASS:  Enabled()
=== RUN   TestEncodedEnvAuth_ShouldReturnAnErrorIfRepoEnvsAreUnset
--- PASS: TestEncodedEnvAuth_ShouldReturnAnErrorIfRepoEnvsAreUnset (0.00s)
=== RUN   TestEncodedEnvAuth_ShouldReturnAuthHashIfRepoEnvsAreSet
--- PASS: TestEncodedEnvAuth_ShouldReturnAuthHashIfRepoEnvsAreSet (0.00s)
=== RUN   TestEncodedConfigAuth_ShouldReturnAnErrorIfFileIsNotPresent
time="2019-11-07T10:59:14+01:00" level=error msg="Unable to parse the image ref repository name must have at least one component"
--- PASS: TestEncodedConfigAuth_ShouldReturnAnErrorIfFileIsNotPresent (0.00s)
=== RUN   TestParseServerAddress_ShouldReturnErrorIfPassedEmptyString
--- PASS: TestParseServerAddress_ShouldReturnErrorIfPassedEmptyString (0.00s)
=== RUN   TestParseServerAddress_ShouldReturnTheRepoNameIfPassedAFullyQualifiedImageName
--- PASS: TestParseServerAddress_ShouldReturnTheRepoNameIfPassedAFullyQualifiedImageName (0.00s)
=== RUN   TestParseServerAddress_ShouldReturnTheOrganizationPartIfPassedAnImageNameMissingServerName
--- PASS: TestParseServerAddress_ShouldReturnTheOrganizationPartIfPassedAnImageNameMissingServerName (0.00s)
=== RUN   TestParseServerAddress_ShouldReturnTheServerNameIfPassedAFullyQualifiedImageName
--- PASS: TestParseServerAddress_ShouldReturnTheServerNameIfPassedAFullyQualifiedImageName (0.00s)
PASS
ok      github.com/containrrr/watchtower/pkg/container  0.032s
?       github.com/containrrr/watchtower/pkg/container/mocks    [no test files]
?       github.com/containrrr/watchtower/pkg/notifications      [no test files]
?       github.com/containrrr/watchtower/pkg/types      [no test files]
```

Manual run:
```bash
$ ./watchtower -i 10 --debug --include-stopped --revive-stopped

DEBU[0000] Sleeping for a second to ensure the docker api client has been properly initialized.
DEBU[0001] Retrieving containers including stopped and exited
DEBU[0001] There are no additional watchtower containers
DEBU[0001] Starting Watchtower and scheduling first run: 2019-11-07 11:07:39 +0100 CET m=+10.410745809
DEBU[0010] Checking containers for updated images
DEBU[0010] Retrieving containers including stopped and exited
DEBU[0010] No pre-check command supplied. Skipping
DEBU[0010] Retrieving containers including stopped and exited
DEBU[0010] Pulling someregistry:5000/maintainer/hello:latest for /hello
DEBU[0010] Loaded auth credentials {******* *******     } for someregistry:5000/maintainer/hello:latest
DEBU[0010] Got auth value: ************************************************
DEBU[0010] Got image name: someregistry:5000/maintainer/hello:latest
INFO[0010] Found new someregistry:5000/maintainer/hello:latest image (sha256:20474fae58e1aeed67bcf0ad5253a690e60f6fff083ea33aafb1c068d78df6a1)
INFO[0010] Executing pre-update command.
ERRO[0010] Error response from daemon: Container 06c616ba696585b9d7e8a9018c71d829302427470b1bc3bb387598e1f6939cda is not running
DEBU[0010] Removing container 06c616ba696585b9d7e8a9018c71d829302427470b1bc3bb387598e1f6939cda
INFO[0010] Creating /hello
DEBU[0011] Starting container /hello (a2e4ebb8638d52180088604e057bd0ac6dcbcc9e1a1b8a09db9fd4906b33af0e)
DEBU[0011] Retrieving containers including stopped and exited
DEBU[0011] No post-check command supplied. Skipping
```

Container was not running:

```
ERRO[0010] Error response from daemon: Container 06c616ba696585b9d7e8a9018c71d829302427470b1bc3bb387598e1f6939cda is not running
```

But was successfully started after watchtower update:
```
DEBU[0011] Starting container /hello (a2e4ebb8638d52180088604e057bd0ac6dcbcc9e1a1b8a09db9fd4906b33af0e)
```