### PR TITLE
docs: add missing description for arguments

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -62,7 +62,7 @@ Enable debug mode with verbose logging.
 
 ```
             Argument: --debug
-Environment Variable: N/A
+Environment Variable: WATCHTOWER_DEBUG
                 Type: Boolean
              Default: false
 ```
@@ -126,6 +126,16 @@ Environment Variable: WATCHTOWER_MONITOR_ONLY
                 Type: Boolean
              Default: false
 ``` 
+
+## Without restarting containers
+Do not restart containers after updating. This option can be useful when the start of the containers
+is managed by an external system such as systemd.
+```
+            Argument: --no-restart
+Environment Variable: WATCHTOWER_NO_RESTART
+                Type: Boolean
+             Default: false
+```
 
 ## Without pulling new images
 Do not pull new images. When this flag is specified, watchtower will not attempt to pull


### PR DESCRIPTION
The proposed changes are
* add a missing argument `--no--restart`
* add a missing environment variable name for the argument `--debug`