### PR TITLE
Small documentation bugfix - Page credential-helpers

### DIFF
--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -51,14 +51,16 @@ and for `<PATH_TO_HOME_DIR>/.docker/config.json`:
     "HttpHeaders" : {
       "User-Agent" : "Docker-Client/19.03.1 (XXXXXX)"
     },
-    "credsStore" : "osxkeychain", // ...or your prefered helper
+    "credsStore" : "osxkeychain",
     "auths" : {
       "xyzxyzxyz.dkr.ecr.eu-north-1.amazonaws.com" : {},
       "https://index.docker.io/v1/": {}
     },
     "credHelpers": {
       "xyzxyzxyz.dkr.ecr.eu-north-1.amazonaws.com" : "ecr-login",
-      "index.docker.io": "osxkeychain" // ...or your prefered helper 
+      "index.docker.io": "osxkeychain"
     }
   }
 ```
+
+*Note:* `osxkeychain` can be changed to your prefered credentials helper

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -46,7 +46,7 @@ volumes:
 ```
 
 and for `<PATH_TO_HOME_DIR>/.docker/config.json`:
-```yaml
+```json
   {
     "HttpHeaders" : {
       "User-Agent" : "Docker-Client/19.03.1 (XXXXXX)"

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -45,7 +45,7 @@ volumes:
   helper: {}
 ```
 
-and for `.docker/config.json`:
+and for `<PATH_TO_HOME_DIR>/.docker/config.json`:
 ```yaml
   {
     "HttpHeaders" : {

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -45,7 +45,7 @@ volumes:
   helper: {}
 ```
 
-and for `.docker/config.yml`:
+and for `.docker/config.json`:
 ```yaml
   {
     "HttpHeaders" : {

--- a/docs/credential-helpers.md
+++ b/docs/credential-helpers.md
@@ -63,4 +63,4 @@ and for `<PATH_TO_HOME_DIR>/.docker/config.json`:
   }
 ```
 
-*Note:* `osxkeychain` can be changed to your prefered credentials helper
+*Note:* `osxkeychain` can be changed to your prefered credentials helper.


### PR DESCRIPTION
This PR fixes a wrong filename in the documentation. The file `config.yml` was mentioned in the documentation, but `config.json` is the correct filename for the settings.