### PR TITLE
Feature | Add github action to build and publish dev image to dockerhub

### DIFF
--- a/.github/workflows/publish-dev-dockerimage.yaml
+++ b/.github/workflows/publish-dev-dockerimage.yaml
@@ -1,0 +1,24 @@
+name: Docker image (latest-dev)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: jerray/publish-docker-action@master
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        path: ./dockerfiles/
+        file: Dockerfile.self-contained
+        repository: containrrr/watchtower
+        tags: latest-dev


### PR DESCRIPTION
Closes #437

This PR adds a github action workflow, to build and push a watchtower docker image with tag: latest-dev, on each commit to master branch.

@simskij you need to add `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` to github secrets, via `<repo url>/settings/secrets`