### PR TITLE
add --no-startup-message flag

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -170,6 +170,16 @@ Environment Variable: WATCHTOWER_NO_PULL
              Default: false
 ``` 
 
+## Without sending a startup message
+Do not send a send a message after watchtower started. Otherwise there will be an info-level notification. 
+
+```
+            Argument: --no-startup-message
+Environment Variable: WATCHTOWER_NO_STARTUP_MESSAGE
+                Type: Boolean
+             Default: false
+```
+
 ## Run once
 Run an update attempt against a container name list one time immediately and exit.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,6 +18,7 @@ The types of notifications to send are set by passing a comma-separated list of 
 ## Settings
 
 - `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info` or `debug`.
+- `--no-startup-message` (env. `WATCHTOWER_NOTIFICATION_NO_STARTUP_MESSAGE`): Prevents watchtower from sending a startup message.
 
 ## Available services
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,7 +18,6 @@ The types of notifications to send are set by passing a comma-separated list of 
 ## Settings
 
 - `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info` or `debug`.
-- `--no-startup-message` (env. `WATCHTOWER_NOTIFICATION_NO_STARTUP_MESSAGE`): Prevents watchtower from sending a startup message.
 
 ## Available services
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -53,6 +53,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"do not restart any containers")
 
 	flags.BoolP(
+		"no-startup-message",
+		"",
+		viper.GetBool("WATCHTOWER_NO_STARTUP_MESSAGE"),
+		"Prevents watchtower from sending a startup message")
+
+	flags.BoolP(
 		"cleanup",
 		"c",
 		viper.GetBool("WATCHTOWER_CLEANUP"),
@@ -122,12 +128,6 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"",
 		viper.GetString("WATCHTOWER_NOTIFICATIONS_LEVEL"),
 		"The log level used for sending notifications. Possible values: panic, fatal, error, warn, info or debug")
-
-	flags.BoolP(
-		"no-startup-message",
-		"",
-		viper.GetBool("WATCHTOWER_NOTIFICATION_NO_STARTUP_MESSAGE"),
-		"Prevents watchtower from sending a startup message")
 
 	flags.StringP(
 		"notification-email-from",

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -123,6 +123,12 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		viper.GetString("WATCHTOWER_NOTIFICATIONS_LEVEL"),
 		"The log level used for sending notifications. Possible values: panic, fatal, error, warn, info or debug")
 
+	flags.BoolP(
+		"no-startup-message",
+		"",
+		viper.GetBool("WATCHTOWER_NOTIFICATION_NO_STARTUP_MESSAGE"),
+		"Prevents watchtower from sending a startup message")
+
 	flags.StringP(
 		"notification-email-from",
 		"",


### PR DESCRIPTION
Added --no-startup-message flag.

I was not quite sure whether I should put it in NotificationFlags or SystemFlags. 
I went for NotificationFlags and documented it in the notification docs.

Fixes #443 