### PR TITLE
fix #472: no-startup-message ignored with run-once

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,9 @@ func Run(c *cobra.Command, names []string) {
 	runOnce, _ := c.PersistentFlags().GetBool("run-once")
 
 	if runOnce {
-		log.Info("Running a one time update.")
+		if noStartupMessage, _ := c.PersistentFlags().GetBool("no-startup-message"); !noStartupMessage {
+			log.Info("Running a one time update.")
+		}
 		runUpdatesWithNotifications(filter)
 		os.Exit(0)
 		return


### PR DESCRIPTION
Fix #472 