### PR TITLE
Add ability to overrider depending containers with special label

### DIFF
--- a/docs/linked-containers.md
+++ b/docs/linked-containers.md
@@ -1,3 +1,5 @@
 Watchtower will detect if there are links between any of the running containers and ensures that things are stopped/started in a way that won't break any of the links. If an update is detected for one of the dependencies in a group of linked containers, watchtower will stop and start all of the containers in the correct order so that the application comes back up correctly.
 
 For example, imagine you were running a _mysql_ container and a _wordpress_ container which had been linked to the _mysql_ container. If watchtower were to detect that the _mysql_ container required an update, it would first shut down the linked _wordpress_ container followed by the _mysql_ container. When restarting the containers it would handle _mysql_ first and then _wordpress_ to ensure that the link continued to work.
+
+If you want to override existing links you can use special `com.centurylinklabs.watchtower.depends-on` label with dependent container names, separated by a comma.

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -95,6 +95,13 @@ func (c Container) Enabled() (bool, bool) {
 func (c Container) Links() []string {
 	var links []string
 
+	dependsOnLabelValue := c.getLabelValueOrEmpty(dependsOnLabel)
+
+	if dependsOnLabelValue != "" {
+		links := strings.Split(dependsOnLabelValue, ",")
+		return links
+	}
+
 	if (c.containerInfo != nil) && (c.containerInfo.HostConfig != nil) {
 		for _, link := range c.containerInfo.HostConfig.Links {
 			name := strings.Split(link, ":")[0]

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -4,6 +4,7 @@ const (
 	watchtowerLabel       = "com.centurylinklabs.watchtower"
 	signalLabel           = "com.centurylinklabs.watchtower.stop-signal"
 	enableLabel           = "com.centurylinklabs.watchtower.enable"
+	dependsOnLabel        = "com.centurylinklabs.watchtower.depends-on"
 	zodiacLabel           = "com.centurylinklabs.zodiac.original-image"
 	preCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.pre-check"
 	postCheckLabel        = "com.centurylinklabs.watchtower.lifecycle.post-check"


### PR DESCRIPTION
Hey!

I decided to introduce new option as discussed on https://github.com/containrrr/watchtower/issues/204.

Assigning new label `com.centurylinklabs.watchtower.depends-on` will override depended containers taken from `HostConfig.Links`, which seems not being used at all these days.

What do you think about that? 