### PR TITLE
Update cron docs link to correct version

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -196,7 +196,7 @@ Environment Variable: WATCHTOWER_RUN_ONCE
 ``` 
 
 ## Scheduling
-[Cron expression](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format) in 6 fields (rather than the traditional 5) which defines when and how often to check for new images. Either `--interval` or the schedule expression 
+[Cron expression](https://pkg.go.dev/github.com/robfig/cron@v1.2.0?tab=doc#hdr-CRON_Expression_Format) in 6 fields (rather than the traditional 5) which defines when and how often to check for new images. Either `--interval` or the schedule expression 
 can be defined, but not both. An example: `--schedule "0 0 4 * * *"`
 
 ```


### PR DESCRIPTION
Update the robfig/cron documentation link which currently points to the v3 version and not the v1 version that watchtower uses.

Fixes #488 