### PR TITLE
feat: add template support for shoutrrr notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -179,6 +179,14 @@ To send notifications via shoutrrr, the following command-line options, or their
 Go to [containrrr.github.io/shoutrrr/services/overview](https://containrrr.github.io/shoutrrr/services/overview) to learn more about the different service URLs you can use.
 You can define multiple services by space separating the URLs. (See example below)
 
+You can customize the message posted by setting a template.
+
+- `--notification-template` (env. `WATCHTOWER_NOTIFICATION_TEMPLATE`): The template used for the message.
+
+The template is a Go [template](https://golang.org/pkg/text/template/) and the you format a list of [log entries](https://pkg.go.dev/github.com/sirupsen/logrus?tab=doc#Entry).
+
+The default value if not set is `{{range .}}{{.Message}}{{println}}{{end}}`. The example below uses a template that also outputs timestamp and log level.
+
 Example:
 
 ```bash
@@ -187,5 +195,6 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e WATCHTOWER_NOTIFICATIONS=shoutrrr \
   -e WATCHTOWER_NOTIFICATION_URL="discord://token@channel slack://watchtower@token-a/token-b/token-c" \
+  -e WATCHTOWER_NOTIFICATION_TEMPLATE="{{range .}}{{.Time.Format \"2006-01-02 15:04:05\"}} ({{.Level}}): {{.Message}}{{println}}{{end}}" \
   containrrr/watchtower
 ```

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -259,6 +259,12 @@ Should only be used for testing.
 		viper.GetString("WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN"),
 		"The Gotify Application required to query the Gotify API")
 
+	flags.StringP(
+		"notification-template",
+		"",
+		viper.GetString("WATCHTOWER_NOTIFICATION_TEMPLATE"),
+		"The shoutrrr text/template for the messages")
+
 	flags.StringArrayP(
 		"notification-url",
 		"",

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -1,0 +1,80 @@
+package notifications
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/containrrr/watchtower/internal/flags"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShoutrrrDefaultTemplate(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	shoutrrr := &shoutrrrTypeNotifier{
+		template: getShoutrrrTemplate(cmd),
+	}
+
+	entries := []*log.Entry{
+		{
+			Message: "foo bar",
+		},
+	}
+
+	s := shoutrrr.buildMessage(entries)
+
+	require.Equal(t, "foo bar\n", s)
+}
+
+func TestShoutrrrTemplate(t *testing.T) {
+	cmd := new(cobra.Command)
+	flags.RegisterNotificationFlags(cmd)
+	err := cmd.ParseFlags([]string{"--notification-template={{range .}}{{.Level}}: {{.Message}}{{println}}{{end}}"})
+
+	require.NoError(t, err)
+
+	shoutrrr := &shoutrrrTypeNotifier{
+		template: getShoutrrrTemplate(cmd),
+	}
+
+	entries := []*log.Entry{
+		{
+			Level:   log.InfoLevel,
+			Message: "foo bar",
+		},
+	}
+
+	s := shoutrrr.buildMessage(entries)
+
+	require.Equal(t, "info: foo bar\n", s)
+}
+
+func TestShoutrrrInvalidTemplateUsesTemplate(t *testing.T) {
+	cmd := new(cobra.Command)
+
+	flags.RegisterNotificationFlags(cmd)
+	err := cmd.ParseFlags([]string{"--notification-template={{"})
+
+	require.NoError(t, err)
+
+	shoutrrr := &shoutrrrTypeNotifier{
+		template: getShoutrrrTemplate(cmd),
+	}
+
+	shoutrrrDefault := &shoutrrrTypeNotifier{
+		template: template.Must(template.New("").Parse(shoutrrrDefaultTemplate)),
+	}
+
+	entries := []*log.Entry{
+		{
+			Message: "foo bar",
+		},
+	}
+
+	s := shoutrrr.buildMessage(entries)
+	sd := shoutrrrDefault.buildMessage(entries)
+
+	require.Equal(t, sd, s)
+}


### PR DESCRIPTION
In https://github.com/containrrr/watchtower/issues/264#issuecomment-612574815 @mbrandau suggested to make timestamp configurable in shoutrrr notifications. The idea has been added as a feature request in https://github.com/containrrr/watchtower/issues/502.

In https://github.com/containrrr/watchtower/issues/264#issuecomment-616231162 I suggested to maybe introduce a template for the messages.

This change introduces a template as a configuration for shoutrrr  notifications.

~~It still missed documentation etc. But I wanted to see what you think of the idea before going ahead.~~

*edit by @simskij:*
resolves #502 