### PR TITLE
Removed all potential debug password prints, both plaintext and encoded

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -13,10 +13,10 @@ func GetPullOptions(imageName string) (types.ImagePullOptions, error) {
 		return types.ImagePullOptions{}, err
 	}
 
-	log.Debugf("Got auth value: %s", auth)
 	if auth == "" {
 		return types.ImagePullOptions{}, nil
 	}
+	log.Debugf("Got auth value")
 
 	return types.ImagePullOptions{
 		RegistryAuth:  auth,

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -36,7 +36,7 @@ func EncodedEnvAuth(ref string) (string, error) {
 			Username: username,
 			Password: password,
 		}
-		log.Debugf("Loaded auth credentials %s for %s", auth, ref)
+		log.Debugf("Loaded auth credentials for user %s on registry %s", auth.Username, ref)
 		return EncodeAuth(auth)
 	}
 	return "", errors.New("Registry auth environment variables (REPO_USER, REPO_PASS) not set")
@@ -68,7 +68,7 @@ func EncodedConfigAuth(ref string) (string, error) {
 		log.Debugf("No credentials for %s in %s", server, configFile.Filename)
 		return "", nil
 	}
-	log.Debugf("Loaded auth credentials %s from %s", auth, configFile.Filename)
+	log.Debugf("Loaded auth credentials for user %s, on registry %s, from file %s", auth.Username, ref, configFile.Filename)
 	return EncodeAuth(auth)
 }
 


### PR DESCRIPTION
Fixes #517.

Changed three debug messages: two in plaintext, one base64 encoded. This should prevent passwords being printed in debug logging.

Debug logging before fix:
```
INFO[0000] Running a one time update.                   
DEBU[0000] Checking containers for updated images       
DEBU[0000] Retrieving running containers                
DEBU[0000] Pulling localhost:5000/alpine for /fervent_roentgen 
DEBU[0000] Loaded auth credentials {testuser testpassword} for localhost:5000/alpine 
DEBU[0000] Got image name: localhost:5000/alpine        
DEBU[0000] Got auth value: eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicGFzc3dvcmQiOiJ0ZXN0cGFzc3dvcmQifQ==
```
Debug logging after fix:
```
INFO[0000] Running a one time update.
DEBU[0000] Checking containers for updated images
DEBU[0002] Retrieving running containers
DEBU[0002] Pulling localhost:5000/alpine for /fervent_roentgen
DEBU[0004] Loaded auth credentials for user testuser on registry localhost:5000/alpine
DEBU[0004] Got image name: localhost:5000/alpine
DEBU[0004] Got auth value
```