### PR TITLE
Added --trace flag and new log.Trace() lines for sensitive information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,9 @@ func PreRun(cmd *cobra.Command, args []string) {
 	if enabled, _ := f.GetBool("debug"); enabled {
 		log.SetLevel(log.DebugLevel)
 	}
+	if enabled, _ := f.GetBool("trace"); enabled {
+		log.SetLevel(log.TraceLevel)
+	}
 
 	pollingSet := f.Changed("interval")
 	schedule, _ := f.GetString("schedule")

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -72,8 +72,18 @@ Environment Variable: WATCHTOWER_REMOVE_VOLUMES
 Enable debug mode with verbose logging.
 
 ```
-            Argument: --debug
+            Argument: --debug, -d
 Environment Variable: WATCHTOWER_DEBUG
+                Type: Boolean
+             Default: false
+```
+
+## Trace
+Enable trace mode with very verbose logging. Caution: exposes credentials!
+
+```
+            Argument: --trace
+Environment Variable: WATCHTOWER_TRACE
                 Type: Boolean
              Default: false
 ```

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,8 +18,8 @@ The types of notifications to send are set by passing a comma-separated list of 
 
 ## Settings
 
-- `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info` or `debug`.
-- Whatchtower will post a notification every time is started. This behavior [can be changed](https://containrrr.github.io/watchtower/arguments/#without_sending_a_startup_message) with an argument. 
+- `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info`, `debug` or `trace`.
+- Watchtower will post a notification every time it is started. This behavior [can be changed](https://containrrr.github.io/watchtower/arguments/#without_sending_a_startup_message) with an argument. 
 
 ## Available services
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -85,6 +85,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"enable debug mode with verbose logging")
 
 	flags.BoolP(
+		"trace",
+		"",
+		viper.GetBool("WATCHTOWER_TRACE"),
+		"enable trace mode with very verbose logging - caution, exposes credentials")
+
+	flags.BoolP(
 		"monitor-only",
 		"m",
 		viper.GetBool("WATCHTOWER_MONITOR_ONLY"),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -16,7 +16,7 @@ func GetPullOptions(imageName string) (types.ImagePullOptions, error) {
 	if auth == "" {
 		return types.ImagePullOptions{}, nil
 	}
-	log.Debugf("Got auth value")
+	log.Tracef("Got auth value: %s", auth)
 
 	return types.ImagePullOptions{
 		RegistryAuth:  auth,

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -37,6 +37,7 @@ func EncodedEnvAuth(ref string) (string, error) {
 			Password: password,
 		}
 		log.Debugf("Loaded auth credentials for user %s on registry %s", auth.Username, ref)
+		log.Tracef("Using auth password %s", auth.Password)
 		return EncodeAuth(auth)
 	}
 	return "", errors.New("Registry auth environment variables (REPO_USER, REPO_PASS) not set")
@@ -69,6 +70,7 @@ func EncodedConfigAuth(ref string) (string, error) {
 		return "", nil
 	}
 	log.Debugf("Loaded auth credentials for user %s, on registry %s, from file %s", auth.Username, ref, configFile.Filename)
+	log.Tracef("Using auth password %s", auth.Password)
 	return EncodeAuth(auth)
 }
 


### PR DESCRIPTION
Fixes #539.

Roughly did the following:
* added new `--trace` flag
* updated documentation with the trace option
* added previously removed credential prints from #517 back under trace log level

Looks like this running:
```
$ ./watchtower --trace -R
INFO[0000] Running a one time update.                   
DEBU[0000] Checking containers for updated images       
DEBU[0000] Retrieving running containers                
DEBU[0000] Pulling localhost:5000/alpine:3.10 for /quizzical_benz 
DEBU[0000] Loaded auth credentials for user user, on registry localhost:5000/alpine:3.10, from file /config.json 
TRAC[0000] Using auth password password                 
DEBU[0000] Got image name: localhost:5000/alpine:3.10   
TRAC[0000] Got auth value: eyJ1c2VybmFtZSI6InVzZXIiLCJwYXNzd29yZCI6InBhc3N3b3JkIiwic2VydmVyYWRkcmVzcyI6ImxvY2FsaG9zdDo1MDAwIn0= 
DEBU[0000] No new images found for /quizzical_benz
```