### PR TITLE
Adds the option to skip TLS verification for a Gotify instance

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -170,6 +170,8 @@ docker run -d \
   containrrr/watchtower
 ```
 
+If you want to disable TLS verification for the Gotify instance, you can use either `-e WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY=true` or `--notification-gotify-tls-skip-verify`. 
+
 ### [containrrr/shoutrrr](https://github.com/containrrr/shoutrrr)
 
 To send notifications via shoutrrr, the following command-line options, or their corresponding environment variables, can be set:

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -183,10 +183,8 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		"notification-email-server-tls-skip-verify",
 		"",
 		viper.GetBool("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY"),
-		`
-Controls whether watchtower verifies the SMTP server's certificate chain and host name.
-Should only be used for testing.
-`)
+		`Controls whether watchtower verifies the SMTP server's certificate chain and host name.
+Should only be used for testing.`)
 
 	flags.StringP(
 		"notification-email-server-user",
@@ -253,11 +251,19 @@ Should only be used for testing.
 		"",
 		viper.GetString("WATCHTOWER_NOTIFICATION_GOTIFY_URL"),
 		"The Gotify URL to send notifications to")
+
 	flags.StringP(
 		"notification-gotify-token",
 		"",
 		viper.GetString("WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN"),
 		"The Gotify Application required to query the Gotify API")
+
+	flags.BoolP(
+		"notification-gotify-tls-skip-verify",
+		"",
+		viper.GetBool("WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY"),
+		`Controls whether watchtower verifies the Gotify server's certificate chain and host name.
+Should only be used for testing.`)
 
 	flags.StringP(
 		"notification-template",

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,7 +18,7 @@ func init() {
 	lock <- true
 }
 
-// SetupHTTPUpdates configures the endopint needed for triggering updates via http
+// SetupHTTPUpdates configures the endpoint needed for triggering updates via http
 func SetupHTTPUpdates(apiToken string, updateFunction func()) error {
 	if apiToken == "" {
 		return errors.New("api token is empty or has not been set. not starting api")


### PR DESCRIPTION
Fixes #382.

Tested this with the following Gotify server using a self-signed certificate:
```
docker run -d -p 443:443 -v /tmp/gotify:/app/data -e GOTIFY_SERVER_SSL_ENABLED=true -e GOTIFY_SERVER_SSL_CERTFILE=/app/data/localhost.crt -e GOTIFY_SERVER_SSL_CERTKEY=/app/data/localhost.key gotify/server
```
With the new flag to the instance as described above:
```
$ ./watchtower --trace --notification-gotify-url=https://localhost:443 --notification-gotify-tls-skip-verify --notification-gotify-token=AL8lZtthYtxzSgw --notifications=gotify -R
INFO[0000] Running a one time update.
DEBU[0000] Checking containers for updated images
```
Without the new flag:
```
$ ./watchtower --trace --notification-gotify-url=https://localhost:443 --notification-gotify-token=AL8lZtthYtxzSgw --notifications=gotify --notifications-level=info -R
INFO[0000] Running a one time update.
Failed to send Gotify notification:  Post "https://localhost:443/message?token=AL8lZtthYtxzSgw": x509: certificate signed by unknown authority
DEBU[0000] Checking containers for updated images
```

And, of course, the notifications were received when the new flag was active :).