### PR TITLE
Allows flags containing sensitive stuff to be passed as files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,7 @@ func PreRun(cmd *cobra.Command, args []string) {
 		scheduleSpec = "@every " + strconv.Itoa(interval) + "s"
 	}
 
+	flags.GetSecretsFromFiles(cmd)
 	cleanup, noRestart, monitorOnly, timeout = flags.ReadFlags(cmd)
 
 	if timeout < 0 {

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -33,7 +33,7 @@ To receive notifications by email, the following command-line options, or their 
 - `--notification-email-server-tls-skip-verify` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_TLS_SKIP_VERIFY`): Do not verify the TLS certificate of the mail server. This should be used only for testing.
 - `--notification-email-server-port` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT`): The port used to connect to the SMTP server to send e-mails through. Defaults to `25`.
 - `--notification-email-server-user` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_USER`): The username to authenticate with the SMTP server with.
-- `--notification-email-server-password` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD`): The password to authenticate with the SMTP server with.
+- `--notification-email-server-password` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD`): The password to authenticate with the SMTP server with. Can also reference a file, in which case the contents of the file are used.
 - `--notification-email-delay` (env. `WATCHTOWER_NOTIFICATION_EMAIL_DELAY`): Delay before sending notifications expressed in seconds.
 - `--notification-email-subjecttag` (env. `WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG`): Prefix to include in the subject tag. Useful when running multiple watchtowers.
 
@@ -110,7 +110,7 @@ If watchtower is monitoring the same Docker daemon under which the watchtower co
 
 To receive notifications in Slack, add `slack` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
 
-Additionally, you should set the Slack webhook URL using the `--notification-slack-hook-url` option or the `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL` environment variable.
+Additionally, you should set the Slack webhook URL using the `--notification-slack-hook-url` option or the `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL` environment variable. This option can also reference a file, in which case the contents of the file are used.
 
 By default, watchtower will send messages under the name `watchtower`, you can customize this string through the `--notification-slack-identifier` option or the `WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER` environment variable.
 
@@ -139,7 +139,7 @@ docker run -d \
 
 To receive notifications in MSTeams channel, add `msteams` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
 
-Additionally, you should set the MSTeams webhook URL using the `--notification-msteams-hook` option or the `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL` environment variable.
+Additionally, you should set the MSTeams webhook URL using the `--notification-msteams-hook` option or the `WATCHTOWER_NOTIFICATION_MSTEAMS_HOOK_URL` environment variable. This option can also reference a file, in which case the contents of the file are used.
 
 MSTeams notifier could send keys/values filled by `log.WithField` or `log.WithFields` as MSTeams message facts. To enable this feature add `--notification-msteams-data` flag or set `WATCHTOWER_NOTIFICATION_MSTEAMS_USE_LOG_DATA=true` environment variable.
 
@@ -159,7 +159,6 @@ docker run -d \
 
 To push a notification to your Gotify instance, register a Gotify app and specify the Gotify URL and app token:
 
-
 ```bash
 docker run -d \
   --name watchtower \
@@ -170,13 +169,15 @@ docker run -d \
   containrrr/watchtower
 ```
 
+`-e WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN` or `--notification-gotify-token` can also reference a file, in which case the contents of the file are used.
+
 If you want to disable TLS verification for the Gotify instance, you can use either `-e WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY=true` or `--notification-gotify-tls-skip-verify`. 
 
 ### [containrrr/shoutrrr](https://github.com/containrrr/shoutrrr)
 
 To send notifications via shoutrrr, the following command-line options, or their corresponding environment variables, can be set:
 
-- `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used.
+- `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used. Can also reference a file, in which case the contents of the file are used.
 
 Go to [containrrr.github.io/shoutrrr/services/overview](https://containrrr.github.io/shoutrrr/services/overview) to learn more about the different service URLs you can use.
 You can define multiple services by space separating the URLs. (See example below)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -177,7 +177,7 @@ If you want to disable TLS verification for the Gotify instance, you can use eit
 
 To send notifications via shoutrrr, the following command-line options, or their corresponding environment variables, can be set:
 
-- `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used. Can also reference a file, in which case the contents of the file are used.
+- `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used.
 
 Go to [containrrr.github.io/shoutrrr/services/overview](https://containrrr.github.io/shoutrrr/services/overview) to learn more about the different service URLs you can use.
 You can define multiple services by space separating the URLs. (See example below)

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	github.com/theupdateframework/notary v0.6.1 // indirect

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -380,7 +380,6 @@ func GetSecretsFromFiles(rootCmd *cobra.Command) {
 		"notification-slack-hook-url",
 		"notification-msteams-hook",
 		"notification-gotify-token",
-		"notification-url",
 	}
 	for _, secret := range secrets {
 		getSecretFromFile(flags, secret)
@@ -409,7 +408,6 @@ func isFile(s string) bool {
 	_, err := os.Stat(s)
 	if os.IsNotExist(err) {
 		return false
-	} else {
-		return true
 	}
+	return true
 }


### PR DESCRIPTION
Potential fix for #532.

I've built in a check to see if the following sensitive options are passed to Watchtower as a file instead of a plaintext secret:
* notification-email-server-password
* notification-slack-hook-url
* notification-msteams-hook
* notification-gotify-token
* ~notification-url~

If this is the case, the runtime value is converted to the contents of the file instead. As the potential for an unexpected conflict is really low (aka a plaintext password that's actually the same as a fully-qualified existing file on the system), it seemed a better option than adding 5 extra flags.

@simskij if you hate this idea and/or have better suggestions, let me know!