### PR TITLE
fix(shoutrrr): display errors on init failure

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -47,7 +47,9 @@ func NewNotifier(c *cobra.Command) *Notifier {
 		default:
 			log.Fatalf("Unknown notification type %q", t)
 		}
-		n.types = append(n.types, tn)
+		if tn != nil {
+			n.types = append(n.types, tn)
+		}
 	}
 
 	return n

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -30,7 +30,11 @@ func newShoutrrrNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Noti
 	flags := c.PersistentFlags()
 
 	urls, _ := flags.GetStringArray("notification-url")
-	r, _ := shoutrrr.CreateSender(urls...)
+	r, err := shoutrrr.CreateSender(urls...)
+	if err != nil {
+		fmt.Printf("Failed to initialize Shoutrrr notifications: %s\n", err.Error())
+		return nil
+	}
 
 	n := &shoutrrrTypeNotifier{
 		Urls:      urls,
@@ -52,8 +56,10 @@ func (e *shoutrrrTypeNotifier) buildMessage(entries []*log.Entry) string {
 }
 
 func (e *shoutrrrTypeNotifier) sendEntries(entries []*log.Entry) {
-	// Do the sending in a separate goroutine so we don't block the main process.
+
 	msg := e.buildMessage(entries)
+
+	// Do the sending in a separate goroutine so we don't block the main process.
 	go func() {
 		errs := e.Router.Send(msg, nil)
 


### PR DESCRIPTION
Errors when initializing shoutrrr are currently just ignored. Reporting them is kind of crucial since the documentation for the shoutrrr services are not completed.

Fixes #555