### PR TITLE
fix(shoutrrr): make shoutrrr init failure a fatal error

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -47,9 +47,7 @@ func NewNotifier(c *cobra.Command) *Notifier {
 		default:
 			log.Fatalf("Unknown notification type %q", t)
 		}
-		if tn != nil {
-			n.types = append(n.types, tn)
-		}
+		n.types = append(n.types, tn)
 	}
 
 	return n

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -32,8 +32,7 @@ func newShoutrrrNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Noti
 	urls, _ := flags.GetStringArray("notification-url")
 	r, err := shoutrrr.CreateSender(urls...)
 	if err != nil {
-		fmt.Printf("Failed to initialize Shoutrrr notifications: %s\n", err.Error())
-		return nil
+		log.Fatalf("Failed to initialize Shoutrrr notifications: %s\n", err.Error())
 	}
 
 	n := &shoutrrrTypeNotifier{
@@ -50,7 +49,9 @@ func newShoutrrrNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Noti
 
 func (e *shoutrrrTypeNotifier) buildMessage(entries []*log.Entry) string {
 	var body bytes.Buffer
-	e.template.Execute(&body, entries)
+	if err := e.template.Execute(&body, entries); err != nil {
+		fmt.Printf("Failed to execute Shoutrrrr template: %s\n", err.Error())
+	}
 
 	return body.String()
 }


### PR DESCRIPTION
When doing #558 I failed to notice that similar problems caused the application to halt, this will align the behaviour of Shoutrrr to the other notification types.

Also writes out any (unlikely) errors from template.Execute instead of ignoring.