### PR TITLE
feat(logging): use human readable log format in stdout/docker logs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,8 @@ func Execute() {
 func PreRun(cmd *cobra.Command, args []string) {
 	f := cmd.PersistentFlags()
 
+	log.SetFormatter(&log.TextFormatter{ForceColors: true, FullTimestamp: true})
+
 	if enabled, _ := f.GetBool("debug"); enabled {
 		log.SetLevel(log.DebugLevel)
 	}


### PR DESCRIPTION
When investigating errors I find it really hard to parse the `logfmt` format that `logrus` outputs whenever it detects a non-TTY output. 
Since the logs are probably most often viewed through `docker logs` it might be a good idea to always use the "human readable" format for logging to stdout.

This PR will make watchtower use the following format in `docker logs`:
```
INFO[2020-05-30T15:10:33+02:00] Starting Watchtower and scheduling first run: 2020-05-30 15:15:33 +0200 CEST m=+301.094569801
```
instead of
```
time="2020-05-30T15:10:33+02:00" level=info msg="Starting Watchtower and scheduling first run: 2020-05-30 15:15:33 +0200 CEST m=+301.094569801"
```