### PR TITLE
Make sure all shoutrrr notifications are sent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,6 +133,7 @@ func Run(c *cobra.Command, names []string) {
 			log.Info("Running a one time update.")
 		}
 		runUpdatesWithNotifications(filter)
+		notifier.Close()
 		os.Exit(0)
 		return
 	}

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -153,3 +153,5 @@ func (e *emailTypeNotifier) Fire(entry *log.Entry) error {
 	}
 	return nil
 }
+
+func (e *emailTypeNotifier) Close() {}

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -59,6 +59,8 @@ func (n *gotifyTypeNotifier) StartNotification() {}
 
 func (n *gotifyTypeNotifier) SendNotification() {}
 
+func (n *gotifyTypeNotifier) Close() {}
+
 func (n *gotifyTypeNotifier) Levels() []log.Level {
 	return n.logLevels
 }

--- a/pkg/notifications/msteams.go
+++ b/pkg/notifications/msteams.go
@@ -47,6 +47,8 @@ func (n *msTeamsTypeNotifier) StartNotification() {}
 
 func (n *msTeamsTypeNotifier) SendNotification() {}
 
+func (n *msTeamsTypeNotifier) Close() {}
+
 func (n *msTeamsTypeNotifier) Levels() []log.Level {
 	return n.levels
 }

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -66,3 +66,10 @@ func (n *Notifier) SendNotification() {
 		t.SendNotification()
 	}
 }
+
+// Close closes all notifiers.
+func (n *Notifier) Close() {
+	for _, t := range n.types {
+		t.Close()
+	}
+}

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"github.com/containrrr/shoutrrr/pkg/types"
 	"testing"
 	"text/template"
 
@@ -77,4 +78,70 @@ func TestShoutrrrInvalidTemplateUsesTemplate(t *testing.T) {
 	sd := shoutrrrDefault.buildMessage(entries)
 
 	require.Equal(t, sd, s)
+}
+
+type blockingRouter struct {
+	unlock chan bool
+	sent   chan bool
+}
+
+func (b blockingRouter) Send(message string, params *types.Params) []error {
+	_ = <-b.unlock
+	b.sent <- true
+	return nil
+}
+
+func TestSlowNotificationNotSent(t *testing.T) {
+	_, blockingRouter := sendNotificationsWithBlockingRouter()
+
+	notifSent := false
+	select {
+	case notifSent = <-blockingRouter.sent:
+	default:
+	}
+
+	require.Equal(t, false, notifSent)
+}
+
+func TestSlowNotificationSent(t *testing.T) {
+	shoutrrr, blockingRouter := sendNotificationsWithBlockingRouter()
+
+	blockingRouter.unlock <- true
+	shoutrrr.Close()
+
+	notifSent := false
+	select {
+	case notifSent = <-blockingRouter.sent:
+	default:
+	}
+	require.Equal(t, true, notifSent)
+}
+
+func sendNotificationsWithBlockingRouter() (*shoutrrrTypeNotifier, *blockingRouter) {
+	cmd := new(cobra.Command)
+
+	router := &blockingRouter{
+		unlock: make(chan bool, 1),
+		sent:   make(chan bool, 1),
+	}
+
+	shoutrrr := &shoutrrrTypeNotifier{
+		template: getShoutrrrTemplate(cmd),
+		messages: make(chan string, 1),
+		done:     make(chan bool),
+		Router:   router,
+	}
+
+	entry := &log.Entry{
+		Message: "foo bar",
+	}
+
+	go sendNotifications(shoutrrr)
+
+	shoutrrr.StartNotification()
+	shoutrrr.Fire(entry)
+
+	shoutrrr.SendNotification()
+
+	return shoutrrr, router
 }

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -42,3 +42,5 @@ func newSlackNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Notifie
 func (s *slackTypeNotifier) StartNotification() {}
 
 func (s *slackTypeNotifier) SendNotification() {}
+
+func (s *slackTypeNotifier) Close() {}

--- a/pkg/types/notifier.go
+++ b/pkg/types/notifier.go
@@ -4,4 +4,5 @@ package types
 type Notifier interface {
 	StartNotification()
 	SendNotification()
+	Close()
 }


### PR DESCRIPTION
When watchtower is launched with --run-once, some notifications might not be sent because the app exits before the goroutine has sent all the notifications.