### PR TITLE
Image of running container no longer needed locally

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -119,12 +119,7 @@ func (client dockerClient) GetContainer(containerID string) (Container, error) {
 		return Container{}, err
 	}
 
-	imageInfo, _, err := client.api.ImageInspectWithRaw(bg, containerInfo.Image)
-	if err != nil {
-		return Container{}, err
-	}
-
-	container := Container{containerInfo: &containerInfo, imageInfo: &imageInfo}
+	container := Container{containerInfo: &containerInfo}
 	return container, nil
 }
 
@@ -244,7 +239,7 @@ func (client dockerClient) IsContainerStale(container Container) (bool, error) {
 }
 
 func (client dockerClient) HasNewImage(ctx context.Context, container Container) (bool, error) {
-	oldImageID := container.imageInfo.ID
+	oldImageID := container.containerInfo.ContainerJSONBase.Image
 	imageName := container.ImageName()
 
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)


### PR DESCRIPTION
Fixes #215 and #495.

Issue arose when a running container did not have the associated image available locally anymore. This was an issue because the sha256 imageID was extracted from the `imageInfo`. However, the sha256 imageID is already present in `containerInfo`, which eliminates the need to even grab the `imageInfo` for running containers.

With this fix, the imageID is now grabbed from `containerInfo`, and getting `imageInfo` from running containers has been removed as it is not needed.