### PR TITLE
Removed accidental dot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-pkg/notifications/smtp.go      @piksel
-pkg/notifications/email.go     @piksel
-pkg/notifications/shoutrrr.go. @piksel @simskij @arnested
-pkg/container/*                @simskij
-pkg/api/*                      @victorcmoura
-.devbots/*                     @simskij
-.github/*                      @simskij
-docs/*                         @containrrr/watchtower-contributors
+pkg/notifications/smtp.go     @piksel
+pkg/notifications/email.go    @piksel
+pkg/notifications/shoutrrr.go @piksel @simskij @arnested
+pkg/container/*               @simskij
+pkg/api/*                     @victorcmoura
+.devbots/*                    @simskij
+.github/*                     @simskij
+docs/*                        @containrrr/watchtower-contributors


### PR DESCRIPTION
Noticed an extra `.` after `pkg/notifications/shoutrrr.go`, pretty sure it shouldn't be there (unless that is some magic syntax I don't know about 😅) 