### PR TITLE
Add argument for setting priority level of Gotify notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -172,6 +172,8 @@ docker run -d \
 
 `-e WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN` or `--notification-gotify-token` can also reference a file, in which case the contents of the file are used.
 
+To specify the priority level for the Gotify notifications, you can use the `WATCHTOWER_NOTIFICATION_GOTIFY_PRIORITY` environment variable or the `--notification-gotify-priority` flag.
+
 If you want to disable TLS verification for the Gotify instance, you can use either `-e WATCHTOWER_NOTIFICATION_GOTIFY_TLS_SKIP_VERIFY=true` or `--notification-gotify-tls-skip-verify`. 
 
 ### [containrrr/shoutrrr](https://github.com/containrrr/shoutrrr)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -261,6 +261,12 @@ Should only be used for testing.`)
 		viper.GetString("WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN"),
 		"The Gotify Application required to query the Gotify API")
 
+	flags.IntP(
+		"notification-gotify-priority",
+		"",
+		viper.GetInt("WATCHTOWER_NOTIFICATION_GOTIFY_PRIORITY"),
+		`Sets the priority level for Gotify notifications`)
+
 	flags.BoolP(
 		"notification-gotify-tls-skip-verify",
 		"",
@@ -293,6 +299,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT", 25)
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG", "")
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
+	viper.SetDefault("WATCHTOWER_NOTIFICATION_GOTIFY_PRIORITY", 0)
 }
 
 // EnvConfig translates the command-line options into environment variables

--- a/pkg/notifications/gotify.go
+++ b/pkg/notifications/gotify.go
@@ -21,6 +21,7 @@ type gotifyTypeNotifier struct {
 	gotifyURL                string
 	gotifyAppToken           string
 	gotifyInsecureSkipVerify bool
+	gotifyPriority           int
 	logLevels                []log.Level
 }
 
@@ -43,10 +44,13 @@ func newGotifyNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Notifi
 
 	gotifyInsecureSkipVerify, _ := flags.GetBool("notification-gotify-tls-skip-verify")
 
+	gotifyPriority, _ := flags.GetInt("notification-gotify-priority")
+
 	n := &gotifyTypeNotifier{
 		gotifyURL:                gotifyURL,
 		gotifyAppToken:           gotifyToken,
 		gotifyInsecureSkipVerify: gotifyInsecureSkipVerify,
+		gotifyPriority:           gotifyPriority,
 		logLevels:                acceptedLogLevels,
 	}
 
@@ -77,7 +81,7 @@ func (n *gotifyTypeNotifier) Fire(entry *log.Entry) error {
 		jsonBody, err := json.Marshal(gotifyMessage{
 			Message:  "(" + entry.Level.String() + "): " + entry.Message,
 			Title:    "Watchtower",
-			Priority: 0,
+			Priority: n.gotifyPriority,
 		})
 		if err != nil {
 			fmt.Println("Failed to create JSON body for Gotify notification: ", err)


### PR DESCRIPTION
I noticed that the priority setting for Gotify notifications was hardcoded as 0. This PR adds an argument, `--notification-gotify-priority` or `WATCHTOWER_NOTIFICATION_GOTIFY_PRIORITY`, to allow the user to set the priority. I kept 0 as the default value.