### PR TITLE
Added by RequireToken (wrapper around http.HandleFunc)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,12 +121,12 @@ func Run(c *cobra.Command, names []string) {
 	httpAPI := api.New(apiToken)
 
 	if enableUpdateAPI {
-		updateHandler := update.New(func() { runUpdatesWithNotifications(filter) }, apiToken)
+		updateHandler := update.New(func() { runUpdatesWithNotifications(filter) })
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 	}
 
 	if enableMetricsAPI {
-		metricsHandler := metrics.New(apiToken)
+		metricsHandler := metrics.New()
 		httpAPI.RegisterHandler(metricsHandler.Path, metricsHandler.Handle)
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,6 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20190404075923-dbe4a30928d4 h1:34LfsqlE2kEvmGP9qbRoPvOWkmluYGzmlvWVTzwvT0A=
 github.com/docker/docker v0.0.0-20190404075923-dbe4a30928d4/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker-credential-helpers v0.6.1 h1:Dq4iIfcM7cNtddhLVWe9h4QDjsi4OER3Z8voPu/I52g=
 github.com/docker/docker-credential-helpers v0.6.1/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go v1.5.1-1 h1:hr4w35acWBPhGBXlzPoHpmZ/ygPjnmFVxGxxGnMyP7k=
@@ -214,7 +213,6 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
-github.com/prometheus/client_golang v1.4.1 h1:FFSuS004yOQEtDdTq+TAOLP5xUq63KqAFYyOi8zA+Y8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
@@ -298,7 +296,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386 h1:ktbWvQrW08Txdxno1PiDpSxPXG6ndGsfnJjRRtkM0LQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,16 +23,28 @@ func New(token string) *API {
 	}
 }
 
+// RequireToken is wrapper around http.HandleFunc that checks token validity
+func (api *API) RequireToken(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Token") != api.Token {
+			log.Error("Invalid token.")
+			return
+		}
+		log.Println("Valid token found.")
+		fn(w, r)
+	}
+}
+
 // RegisterFunc is a wrapper around http.HandleFunc that also flips the bool used to determine whether to launch the API
 func (api *API) RegisterFunc(path string, fn http.HandlerFunc) {
 	api.hasHandlers = true
-	http.HandleFunc(path, fn)
+	http.HandleFunc(path, api.RequireToken(fn))
 }
 
 // RegisterHandler is a wrapper around http.Handler that also flips the bool used to determine whether to launch the API
 func (api *API) RegisterHandler(path string, handler http.Handler) {
 	api.hasHandlers = true
-	http.Handle(path, handler)
+	http.Handle(path, api.RequireToken(handler.ServeHTTP))
 }
 
 // Start the API and serve over HTTP. Requires an API Token to be set.

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +25,7 @@ type Handler struct {
 }
 
 // New is a factory function creating a new Metrics instance
-func New(token string) *Handler {
+func New() *Handler {
 	metrics := &Metrics{}
 	metrics.scanned = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "watchtower_containers_scanned",
@@ -50,18 +49,10 @@ func New(token string) *Handler {
 	})
 
 	handler := promhttp.Handler()
-	authAndHandle := func(w http.ResponseWriter, r *http.Request) {
-		// Hijacking the prometheus handler and adding a token check
-		if r.Header.Get("Token") != token {
-			log.Error("Invalid token. Not serving any metrics.")
-			return
-		}
-		handler.ServeHTTP(w, r)
-	}
 
 	return &Handler{
 		Path:    "/v1/metrics",
-		Handle:  authAndHandle,
+		Handle:  handler.ServeHTTP,
 		Metrics: metrics,
 	}
 }

--- a/pkg/api/metrics/metrics_test.go
+++ b/pkg/api/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	"fmt"
+	"github.com/containrrr/watchtower/pkg/api"
 	"github.com/containrrr/watchtower/pkg/api/metrics"
 	"io/ioutil"
 	"net/http"
@@ -18,13 +19,6 @@ func TestContainer(t *testing.T) {
 	RunSpecs(t, "Metrics Suite")
 }
 
-func runTestServer(m *metrics.Handler) {
-	http.Handle(m.Path, m.Handle)
-	go func() {
-		http.ListenAndServe(":8080", nil)
-	}()
-}
-
 func getWithToken(c http.Client, url string) (*http.Response, error) {
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Add("Token", Token)
@@ -32,8 +26,10 @@ func getWithToken(c http.Client, url string) (*http.Response, error) {
 }
 
 var _ = Describe("the metrics", func() {
-	m := metrics.New(Token)
-	runTestServer(m)
+	httpAPI := api.New(Token)
+	m := metrics.New()
+	httpAPI.RegisterHandler(m.Path, m.Handle)
+	httpAPI.Start(false)
 
 	// We should likely split this into multiple tests, but as prometheus requires a restart of the binary
 	// to reset the metrics and gauges, we'll just do it all at once.

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -12,22 +12,20 @@ var (
 )
 
 // New is a factory function creating a new  Handler instance
-func New(updateFn func(), token string) *Handler {
+func New(updateFn func()) *Handler {
 	lock = make(chan bool, 1)
 	lock <- true
 
 	return &Handler{
-		fn:    updateFn,
-		token: token,
-		Path:  "/v1/update",
+		fn:   updateFn,
+		Path: "/v1/update",
 	}
 }
 
 // Handler is an API handler used for triggering container update scans
 type Handler struct {
-	fn    func()
-	token string
-	Path  string
+	fn   func()
+	Path string
 }
 
 // Handle is the actual http.Handle function doing all the heavy lifting
@@ -39,13 +37,6 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-
-	if r.Header.Get("Token") != handle.token {
-		log.Error("Invalid token. Not updating.")
-		return
-	}
-
-	log.Println("Valid token found. Attempting to update.")
 
 	select {
 	case chanValue := <-lock:


### PR DESCRIPTION
Hello. I suggest this solution for  #581 issue. 

I created the required wrapper in the `api.go` file and deleted the existing token checks in the `metrics.go` and `update.go` files. And accordingly changed the `metrics.New()` and `update.New()` methods.