### PR TITLE
Warning if `WATCHTOWER_NO_PULL` and` WATCHTOWER_MONITOR_ONLY` are used simultaneously.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,6 +102,11 @@ func PreRun(cmd *cobra.Command, args []string) {
 	reviveStopped, _ := f.GetBool("revive-stopped")
 	removeVolumes, _ := f.GetBool("remove-volumes")
 
+	if monitorOnly && noPull {
+		log.Warn("Using `WATCHTOWER_NO_PULL` simultaneously with `WATCHTOWER_MONITOR_ONLY`" +
+			" may be unintentional and lead to undesirable consequences.")
+	}
+
 	client = container.NewClient(
 		!noPull,
 		includeStopped,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,8 +103,7 @@ func PreRun(cmd *cobra.Command, args []string) {
 	removeVolumes, _ := f.GetBool("remove-volumes")
 
 	if monitorOnly && noPull {
-		log.Warn("Using `WATCHTOWER_NO_PULL` simultaneously with `WATCHTOWER_MONITOR_ONLY`" +
-			" may be unintentional and lead to undesirable consequences.")
+		log.Warn("Using `WATCHTOWER_NO_PULL` and `WATCHTOWER_MONITOR_ONLY` simultaneously might lead to no action being taken at all. If this is intentional, you may safely ignore this message.")
 	}
 
 	client = container.NewClient(


### PR DESCRIPTION
A warning was added if `WATCHTOWER_NO_PULL` and` WATCHTOWER_MONITOR_ONLY` are used simultaneously. Closes #570 