### PR TITLE
Fix typo

### DIFF
--- a/docs/container-selection.md
+++ b/docs/container-selection.md
@@ -12,7 +12,7 @@ Or, it can be specified as part of the `docker run` command line:
 docker run -d --label=com.centurylinklabs.watchtower.enable=false someimage
 ```
 
-If you need to [include only containers with the enable label](https://containrrr.github.io/watchtower/arguments/#filter_by_enable_label), pass the `--label-enable` flag or the  `WATCTOWER_LABEL_ENABLE` environment variable on startup and set the _com.centurylinklabs.watchtower.enable_ label with a value of `true` for the containers you want to watch.
+If you need to [include only containers with the enable label](https://containrrr.github.io/watchtower/arguments/#filter_by_enable_label), pass the `--label-enable` flag or the `WATCHTOWER_LABEL_ENABLE` environment variable on startup and set the _com.centurylinklabs.watchtower.enable_ label with a value of `true` for the containers you want to watch.
 
 ```docker
 LABEL com.centurylinklabs.watchtower.enable="true"


### PR DESCRIPTION
Fixes the typo `WATCTOWER_LABEL_ENABLE` on `Container selection` page.