### PR TITLE
lifecycle logs as Debug instead of Info

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -36,7 +36,7 @@ func ExecutePreCheckCommand(client container.Client, container container.Contain
 		return
 	}
 
-	log.Info("Executing pre-check command.")
+	log.Debug("Executing pre-check command.")
 	if err := client.ExecuteCommand(container.ID(), command, 1); err != nil {
 		log.Error(err)
 	}
@@ -50,7 +50,7 @@ func ExecutePostCheckCommand(client container.Client, container container.Contai
 		return
 	}
 
-	log.Info("Executing post-check command.")
+	log.Debug("Executing post-check command.")
 	if err := client.ExecuteCommand(container.ID(), command, 1); err != nil {
 		log.Error(err)
 	}
@@ -65,7 +65,7 @@ func ExecutePreUpdateCommand(client container.Client, container container.Contai
 		return nil
 	}
 
-	log.Info("Executing pre-update command.")
+	log.Debug("Executing pre-update command.")
 	return client.ExecuteCommand(container.ID(), command, timeout)
 }
 
@@ -83,7 +83,7 @@ func ExecutePostUpdateCommand(client container.Client, newContainerID string) {
 		return
 	}
 
-	log.Info("Executing post-update command.")
+	log.Debug("Executing post-update command.")
 	if err := client.ExecuteCommand(newContainerID, command, 1); err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
The life-cycle messages should not have the same level as the update messages.

#### Why?
I receive a (mail-) notification for every run even if no image is changed: 
```
2020-07-31 06:44:33 (info): Executing pre-check command.
```

But I only want to receive a notification if something changed:
```
2020-07-20 06:44:44 (info): Found new traefik:v2.2 image (sha256:7c992081f52423e325bd12debf0edcb4f7cfa398683c26f99c00112ec14e1ab9)
```