### PR TITLE
Skip updating containers where no local image info can be retrieved

### DIFF
--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"errors"
 	"github.com/containrrr/watchtower/internal/util"
 	"github.com/containrrr/watchtower/pkg/container"
 	"github.com/containrrr/watchtower/pkg/lifecycle"
@@ -25,11 +26,13 @@ func Update(client container.Client, params types.UpdateParams) error {
 		return err
 	}
 
-	for i, container := range containers {
-		stale, err := client.IsContainerStale(container)
+	for i, targetContainer := range containers {
+		stale, err := client.IsContainerStale(targetContainer)
+		if stale && !params.NoRestart && !params.MonitorOnly && !targetContainer.HasImageInfo() {
+			err = errors.New("no available image info")
+		}
 		if err != nil {
-			log.Infof("Unable to update container %s. Proceeding to next.", containers[i].Name())
-			log.Debug(err)
+			log.Infof("Unable to update container %q: %v. Proceeding to next.", containers[i].Name(), err)
 			stale = false
 		}
 		containers[i].Stale = stale
@@ -89,12 +92,12 @@ func stopStaleContainer(container container.Container, client container.Client, 
 func restartContainersInSortedOrder(containers []container.Container, client container.Client, params types.UpdateParams) {
 	imageIDs := make(map[string]bool)
 
-	for _, container := range containers {
-		if !container.Stale {
+	for _, staleContainer := range containers {
+		if !staleContainer.Stale {
 			continue
 		}
-		restartStaleContainer(container, client, params)
-		imageIDs[container.ImageID()] = true
+		restartStaleContainer(staleContainer, client, params)
+		imageIDs[staleContainer.ImageID()] = true
 	}
 	if params.Cleanup {
 		for imageID := range imageIDs {

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -121,11 +121,10 @@ func (client dockerClient) GetContainer(containerID string) (Container, error) {
 
 	imageInfo, _, err := client.api.ImageInspectWithRaw(bg, containerInfo.Image)
 	if err != nil {
-		return Container{}, err
+		log.Warnf("Failed to retrieve container image info: %v", err)
 	}
 
-	container := Container{containerInfo: &containerInfo, imageInfo: &imageInfo}
-	return container, nil
+	return Container{containerInfo: &containerInfo, imageInfo: &imageInfo}, nil
 }
 
 func (client dockerClient) StopContainer(c Container, timeout time.Duration) error {

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -244,7 +244,7 @@ func (client dockerClient) IsContainerStale(container Container) (bool, error) {
 }
 
 func (client dockerClient) HasNewImage(ctx context.Context, container Container) (bool, error) {
-	oldImageID := container.imageInfo.ID
+	oldImageID := container.containerInfo.ContainerJSONBase.Image
 	imageName := container.ImageName()
 
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -119,7 +119,12 @@ func (client dockerClient) GetContainer(containerID string) (Container, error) {
 		return Container{}, err
 	}
 
-	container := Container{containerInfo: &containerInfo}
+	imageInfo, _, err := client.api.ImageInspectWithRaw(bg, containerInfo.Image)
+	if err != nil {
+		return Container{}, err
+	}
+
+	container := Container{containerInfo: &containerInfo, imageInfo: &imageInfo}
 	return container, nil
 }
 
@@ -239,7 +244,7 @@ func (client dockerClient) IsContainerStale(container Container) (bool, error) {
 }
 
 func (client dockerClient) HasNewImage(ctx context.Context, container Container) (bool, error) {
-	oldImageID := container.containerInfo.ContainerJSONBase.Image
+	oldImageID := container.imageInfo.ID
 	imageName := container.ImageName()
 
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -221,3 +221,8 @@ func (c Container) hostConfig() *dockercontainer.HostConfig {
 
 	return hostConfig
 }
+
+// HasImageInfo returns whether image information could be retrieved for the container
+func (c Container) HasImageInfo() bool {
+	return c.imageInfo != nil
+}


### PR DESCRIPTION
Partially reverts containrrr/watchtower#571, since it causes `dockerClient.StartContainer()` to crash since it uses `imageInfo` to rebuild the config.

Fixes #584 