### PR TITLE
fix: return nil imageinfo when retrieve fails

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -122,6 +122,7 @@ func (client dockerClient) GetContainer(containerID string) (Container, error) {
 	imageInfo, _, err := client.api.ImageInspectWithRaw(bg, containerInfo.Image)
 	if err != nil {
 		log.Warnf("Failed to retrieve container image info: %v", err)
+		return Container{containerInfo: &containerInfo, imageInfo: nil}, nil
 	}
 
 	return Container{containerInfo: &containerInfo, imageInfo: &imageInfo}, nil


### PR DESCRIPTION
This is an update to #612 since that one presumed (wrongly) that the `ImageInfo` returned by the API on failure would be nil.

Fixes #677 