### PR TITLE
fix host flag

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -102,7 +102,7 @@ Environment Variable: NO_COLOR
 Docker daemon socket to connect to. Can be pointed at a remote Docker host by specifying a TCP endpoint as "tcp://hostname:port".
 
 ```
-            Argument: --host, -h
+            Argument: --host, -H
 Environment Variable: DOCKER_HOST
                 Type: String
              Default: "unix:///var/run/docker.sock"


### PR DESCRIPTION
I was following the wiki and trying to use the short format for specifying the docker host with `-h`. It was just spitting out the usage info, and I noticed it was showing `-H`.

The wiki shows the syntax as `--host` or `-h` but `docker run --rm containrrr/watchtower --help` shows `-H`.
