### PR TITLE
fix default interval to be the intended value

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -300,7 +300,7 @@ Should only be used for testing.`)
 
 // SetDefaults provides default values for environment variables
 func SetDefaults() {
-	day := time.Hour * 24 / time.Second
+	day := (time.Hour * 24).Seconds()
 	viper.AutomaticEnv()
 	viper.SetDefault("DOCKER_HOST", "unix:///var/run/docker.sock")
 	viper.SetDefault("DOCKER_API_VERSION", DockerAPIMinVersion)


### PR DESCRIPTION
```
time.Hour * 24 / time.Second = 86.4µs
(time.Hour * 24) / time.Second = 86.4µs
(time.Hour * 24).Seconds() = 86400
```
https://play.golang.org/p/2KZUMBe0X_d