### PR TITLE
add defered closer calls for the http clients

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -37,7 +37,7 @@ func GetToken(container types.Container, registryAuth string) (string, error) {
 	if res, err = client.Do(req); err != nil {
 		return "", err
 	}
-
+	defer res.Body.Close()
 	v := res.Header.Get(ChallengeHeader)
 
 	logrus.WithFields(logrus.Fields{

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -91,6 +91,8 @@ func GetDigest(url string, token string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
+
 	if res.StatusCode != 200 {
 		return "", fmt.Errorf("registry responded to head request with %d", res.StatusCode)
 	}


### PR DESCRIPTION
add defered closer calls for the http client to avoid leaking file descriptors