### PR TITLE
move secret value "credentials" to trace log

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -89,7 +89,8 @@ func GetBearerHeader(challenge string, img string, err error, registryAuth strin
 	}
 
 	if registryAuth != "" {
-		logrus.WithField("credentials", registryAuth).Debug("Credentials found.")
+		logrus.Debug("Credentials found.")
+		logrus.Tracef("Credentials: %v", registryAuth)
 		r.Header.Add("Authorization", fmt.Sprintf("Basic %s", registryAuth))
 	} else {
 		logrus.Debug("No credentials found.")


### PR DESCRIPTION
this moves the registry auth credentials from `Debug` output to `Trace` as it's value should be classified as a secret.