### PR TITLE
Log based on registry known-support - reduce noise on notifications

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -295,7 +295,11 @@ func (client dockerClient) PullImage(ctx context.Context, container Container) e
 	log.WithFields(fields).Debugf("Checking if pull is needed")
 
 	if match, err := digest.CompareDigest(container, opts.RegistryAuth); err != nil {
-		log.Info("Could not do a head request, falling back to regular pull.")
+		if registry.WarnOnAPIConsumption(container) {
+			log.WithFields(fields).Warning("Could not do a head request, falling back to regular pull.")
+		} else {
+			log.Debug("Could not do a head request, falling back to regular pull.")
+		}
 		log.Debugf("Reason: %s", err.Error())
 	} else if match {
 		log.Debug("No pull needed. Skipping image.")


### PR DESCRIPTION
Some private registries do not support HEAD (E.G. GitLab Container Registry).
With the current config, this log message is causing a notification to be
sent for each container hosted in a registry lacking HEAD support.

Attempt to `log.Debug` or `log.Warning` for failed HTTP HEAD-check based on
registry hostname.  For Docker Hub, a failed HEAD may count against a
user's call-quota whereas other registry implementations do not support HEAD.

Fixes #715 