### PR TITLE
Add WATCHTOWER_INCLUDE_RESTARTING env for include-restarting flag

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -118,6 +118,16 @@ Environment Variable: DOCKER_API_VERSION
              Default: "1.24"
 ```
 
+## Include restarting
+Will also include created and exited containers.
+
+```
+            Argument: --include-restarting
+Environment Variable: WATCHTOWER_INCLUDE_RESTARTING
+                Type: Boolean
+             Default: false
+```
+
 ## Include stopped
 Will also include created and exited containers.
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -106,6 +106,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Run once now and exit")
 
 	flags.BoolP(
+		"include-restarting",
+		"",
+		viper.GetBool("WATCHTOWER_INCLUDE_RESTARTING"),
+		"Will also include restarting containers")
+
+	flags.BoolP(
 		"include-stopped",
 		"S",
 		viper.GetBool("WATCHTOWER_INCLUDE_STOPPED"),


### PR DESCRIPTION
Follows up #651 to add environment variable and documentation.

Single letter flag not included as the most obvious option, mirroring `include-stopped` and using `-R`, is already taken by `run-once`.

This is just a c&p job, so no worries if this isn't needed/wanted, it took me all of 2mins.