### PR TITLE
add details/summary to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,14 @@ If applicable, add screenshots to help explain your problem.
  - Architecture
  - Docker version 
 
-**Logs from running watchtower with the `--debug` option**
+<details>
+ <summary><b> Logs from running watchtower with the <code>--debug</code> option </b></summary>
+
+```
+
+```
+
+</details>
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
This will make the log section of an issue expandable (and preformatted) by default.

<details>
<summary>Like this</summary>

```
This is really useful when reading large amounts of text from the console, like logs etc.
The problem is that it's neither-well known, nor easy to get right since you need to put a single 
blank line separating HTML and markdown parts.
```

</details>

Not sure if it's clear enough for people creating the issue how to correctly fill it in. A comment (`<!-- -->`) could be added to explain where to put the log rows, but it might also just be more confusing....