### PR TITLE
Added a link to HTTP API documentation

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -221,7 +221,7 @@ Environment Variable: WATCHTOWER_RUN_ONCE
 ```
 
 ## HTTP API Mode
-Runs Watchtower in HTTP API mode, only allowing image updates to be triggered by an HTTP request.
+Runs Watchtower in HTTP API mode, only allowing image updates to be triggered by an HTTP request. For details see [HTTP API](https://containrrr.github.io/watchtower/http-api-mode).
 
 ```
             Argument: --http-api


### PR DESCRIPTION
Every time I needed to use the HTTP API, I spent 15 minutes to find the docs... Apparently, the documentation is there, but there is no link to it, so I added it. Thanks.