### PR TITLE
chore(ci): disable fail-fast for pr tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         go-version:
           - 1.15.x


### PR DESCRIPTION
This will make the `Test` step continue even if one platform errors out (not naming names here, wintendo). Also useful to get an indication of whether the problem is OS-specific when all builds should work normally.