### PR TITLE
feat: include additional info in startup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+VERSION=$(git describe)
+echo "Building $VERSION..."
+go build -o watchtower -ldflags "-X github.com/containrrr/watchtower/cmd.version=$VERSION"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,8 @@ var (
 	lifecycleHooks bool
 	rollingRestart bool
 	scope          string
-	version        string = "v0.0.0-unknown"
+	// Set on build using ldflags
+	version = "v0.0.0-unknown"
 )
 
 var rootCmd = NewRootCommand()

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -114,7 +114,8 @@ func TestBuildFilter(t *testing.T) {
 	var names []string
 	names = append(names, "test")
 
-	filter := BuildFilter(names, false, "")
+	filter, desc := BuildFilter(names, false, "")
+	assert.Contains(t, desc, "test")
 
 	container := new(mocks.FilterableContainer)
 	container.On("Name").Return("Invalid")
@@ -150,7 +151,8 @@ func TestBuildFilterEnableLabel(t *testing.T) {
 	var names []string
 	names = append(names, "test")
 
-	filter := BuildFilter(names, true, "")
+	filter, desc := BuildFilter(names, true, "")
+	assert.Contains(t, desc, "using enable label")
 
 	container := new(mocks.FilterableContainer)
 	container.On("Enabled").Return(false, false)

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"os"
+	"strings"
 )
 
 // Notifier can send log output as notification to admins, with optional batching.
@@ -40,6 +41,26 @@ func NewNotifier(c *cobra.Command) *Notifier {
 	n.types = n.getNotificationTypes(c, acceptedLogLevels, types)
 
 	return n
+}
+
+func (n *Notifier) String() string {
+	if len(n.types) < 1 {
+		return ""
+	}
+
+	sb := strings.Builder{}
+	for _, notif := range n.types {
+		for _, name := range notif.GetNames() {
+			sb.WriteString(name)
+			sb.WriteString(", ")
+		}
+	}
+	names := sb.String()
+
+	// remove the last separator
+	names = names[:len(names)-2]
+
+	return names
 }
 
 // getNotificationTypes produces an array of notifiers from a list of types

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -49,13 +49,13 @@ func (n *shoutrrrTypeNotifier) GetNames() []string {
 func newShoutrrrNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Notifier {
 	flags := c.PersistentFlags()
 	urls, _ := flags.GetStringArray("notification-url")
-	template := getShoutrrrTemplate(c)
-	return createSender(urls, acceptedLogLevels, template)
+	tpl := getShoutrrrTemplate(c)
+	return createSender(urls, acceptedLogLevels, tpl)
 }
 
 func newShoutrrrNotifierFromURL(c *cobra.Command, url string, levels []log.Level) t.Notifier {
-	template := getShoutrrrTemplate(c)
-	return createSender([]string{url}, levels, template)
+	tpl := getShoutrrrTemplate(c)
+	return createSender([]string{url}, levels, tpl)
 }
 
 func createSender(urls []string, levels []log.Level, template *template.Template) t.Notifier {
@@ -96,54 +96,54 @@ func sendNotifications(n *shoutrrrTypeNotifier) {
 	n.done <- true
 }
 
-func (e *shoutrrrTypeNotifier) buildMessage(entries []*log.Entry) string {
+func (n *shoutrrrTypeNotifier) buildMessage(entries []*log.Entry) string {
 	var body bytes.Buffer
-	if err := e.template.Execute(&body, entries); err != nil {
+	if err := n.template.Execute(&body, entries); err != nil {
 		fmt.Printf("Failed to execute Shoutrrrr template: %s\n", err.Error())
 	}
 
 	return body.String()
 }
 
-func (e *shoutrrrTypeNotifier) sendEntries(entries []*log.Entry) {
-	msg := e.buildMessage(entries)
-	e.messages <- msg
+func (n *shoutrrrTypeNotifier) sendEntries(entries []*log.Entry) {
+	msg := n.buildMessage(entries)
+	n.messages <- msg
 }
 
-func (e *shoutrrrTypeNotifier) StartNotification() {
-	if e.entries == nil {
-		e.entries = make([]*log.Entry, 0, 10)
+func (n *shoutrrrTypeNotifier) StartNotification() {
+	if n.entries == nil {
+		n.entries = make([]*log.Entry, 0, 10)
 	}
 }
 
-func (e *shoutrrrTypeNotifier) SendNotification() {
-	if e.entries == nil || len(e.entries) <= 0 {
+func (n *shoutrrrTypeNotifier) SendNotification() {
+	if n.entries == nil || len(n.entries) <= 0 {
 		return
 	}
 
-	e.sendEntries(e.entries)
-	e.entries = nil
+	n.sendEntries(n.entries)
+	n.entries = nil
 }
 
-func (e *shoutrrrTypeNotifier) Close() {
-	close(e.messages)
+func (n *shoutrrrTypeNotifier) Close() {
+	close(n.messages)
 
 	// Use fmt so it doesn't trigger another notification.
 	fmt.Println("Waiting for the notification goroutine to finish")
 
-	_ = <-e.done
+	_ = <-n.done
 }
 
-func (e *shoutrrrTypeNotifier) Levels() []log.Level {
-	return e.logLevels
+func (n *shoutrrrTypeNotifier) Levels() []log.Level {
+	return n.logLevels
 }
 
-func (e *shoutrrrTypeNotifier) Fire(entry *log.Entry) error {
-	if e.entries != nil {
-		e.entries = append(e.entries, entry)
+func (n *shoutrrrTypeNotifier) Fire(entry *log.Entry) error {
+	if n.entries != nil {
+		n.entries = append(n.entries, entry)
 	} else {
 		// Log output generated outside a cycle is sent immediately.
-		e.sendEntries([]*log.Entry{entry})
+		n.sendEntries([]*log.Entry{entry})
 	}
 	return nil
 }

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -33,6 +33,19 @@ type shoutrrrTypeNotifier struct {
 	done      chan bool
 }
 
+func (n *shoutrrrTypeNotifier) GetNames() []string {
+	names := make([]string, len(n.Urls))
+	for i, u := range n.Urls {
+		schemeEnd := strings.Index(u, ":")
+		if schemeEnd <= 0 {
+			names[i] = "invalid"
+			continue
+		}
+		names[i] = u[:schemeEnd]
+	}
+	return names
+}
+
 func newShoutrrrNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Notifier {
 	flags := c.PersistentFlags()
 	urls, _ := flags.GetStringArray("notification-url")

--- a/pkg/types/notifier.go
+++ b/pkg/types/notifier.go
@@ -4,5 +4,6 @@ package types
 type Notifier interface {
 	StartNotification()
 	SendNotification()
+	GetNames() []string
 	Close()
 }


### PR DESCRIPTION
I am investigating alternative startup messages for Watchtower, based on the common issues users seem to have. This is the proposed output from run once:
```
$ ./watchtower --run-once --notifications gotify,shoutrrr --scope 15xPMII foo bar --debug true --label-enable
INFO[0000] Watchtower v1.1.6
Using notifications: gotify, smtp
Only checking containers with name "foo" or "bar" or "true", using enable label, in scope "15xPMII"
Running a one time update.
Waiting for the notification goroutine to finish
Waiting for the notification goroutine to finish
```
And this is the corresponding one for interval/schedule/--not-run-once:
```
./watchtower --notifications gotify,shoutrrr foo bar --label-enable
INFO[0001] Watchtower v1.1.6
Using notifications: gotify, smtp
Only checking containers with name "foo" or "bar", using enable label
Scheduling first run: 2021-01-31 13:53:08 +0100 CET
Note that the first check will be performed in 23 hours, 59 minutes, 59 seconds
INFO[0039] Waiting for running update to be finished...
```