### PR TITLE
chore(ci): set image platform on image build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,5 +69,5 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.104.1
+          version: v0.155.0
           args: --snapshot --skip-publish --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15.x
-      - name: Run goreleaser
+      - name: Build
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.104.1
+          version: v0.155.0
           args: --debug
       - name: Enable experimental docker features
         run: |

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as alpine
+FROM --platform=$BUILDPLATFORM alpine:3.11 as alpine
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -9,7 +9,7 @@ build:
     - 386
     - arm
     - arm64
-archive:
+archives:
   name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
   format: tar.gz
   replacements:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -26,6 +26,8 @@ archive:
     - LICENSE.md
 dockers:
   -
+    use_buildx: true
+    build_flag_templates: [ "--platform=linux/amd64" ]
     goos: linux
     goarch: amd64
     goarm: ''
@@ -35,7 +37,9 @@ dockers:
       - containrrr/watchtower:amd64-latest
     binaries:
       - watchtower
-  -
+  - 
+    use_buildx: true
+    build_flag_templates: [ "--platform=linux/386" ]
     goos: linux
     goarch: 386
     goarm: ''
@@ -45,7 +49,9 @@ dockers:
       - containrrr/watchtower:i386-latest
     binaries:
       - watchtower
-  -
+  - 
+    use_buildx: true
+    build_flag_templates: [ "--platform=linux/arm/v6" ]
     goos: linux
     goarch: arm
     goarm: 6
@@ -55,7 +61,9 @@ dockers:
       - containrrr/watchtower:armhf-latest
     binaries:
       - watchtower
-  -
+  - 
+    use_buildx: true
+    build_flag_templates: [ "--platform=linux/arm64/v8" ]
     goos: linux
     goarch: arm64
     goarm: ''

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -10,20 +10,21 @@ build:
     - arm
     - arm64
 archives:
-  name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
-  format: tar.gz
-  replacements:
-    arm: armhf
-    arm64: arm64v8
-    amd64: amd64
-    386: 386
-    darwin: macOS
-    linux: linux
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-    - LICENSE.md
+  - 
+    name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
+    format: tar.gz
+    replacements:
+      arm: armhf
+      arm64: arm64v8
+      amd64: amd64
+      386: 386
+      darwin: macOS
+      linux: linux
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE.md
 dockers:
   -
     use_buildx: true


### PR DESCRIPTION
When building the docker images, if no platform is specified and the `FROM` image is `scratch`, docker will use the builders current platform.
~~This will explicitly set the platform when building to fix issues running the images on ARM using the latest  docker versions.
Unfortunatly, this means that the `Dockerfile` now only can be built using `buildx` as it copies files from alpine that needs to match the builders platform.~~
**Update:** Removed the `--from` in the `Dockerfile` as it isn't strictly necessary. It saves downloading extra images, but otherwise it works fine with the target platforms versions of alpine.

Fixes #779 