### PR TITLE
Set different default branch for mkdocs edit

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Watchtower
 site_url: http://containrrr.github.io/watchtower/
 repo_url: https://github.com/containrrr/watchtower/
+edit_uri: edit/main/docs/index.md
 theme:
   name: 'material'
   palette:


### PR DESCRIPTION
From mkdocs [documentation](https://www.mkdocs.org/user-guide/configuration/#edit_uri):

```
Note

On a few known hosts (specifically GitHub, Bitbucket and GitLab), the edit_uri is derived from the 'repo_url' and does not need to be set manually. Simply defining a repo_url will automatically populate the edit_uri configs setting.

For example, for a GitHub- or GitLab-hosted repository, the edit_uri would be automatically set as edit/master/docs/ (Note the edit path and master branch).

For a Bitbucket-hosted repository, the equivalent edit_uri would be automatically set as src/default/docs/ (note the src path and default branch).

To use a different URI than the default (for example a different branch), simply set the edit_uri to your desired string. If you do not want any "edit URL link" displayed on your pages, then set edit_uri to an empty string to disable the automatic setting.
```

Hopefully closes #845