### PR TITLE
docs: suggest mounting localtime, not timezone

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -39,7 +39,7 @@ Environment Variable: N/A
 
 ## Time Zone
 Sets the time zone to be used by WatchTower's logs and the optional Cron scheduling argument (--schedule). If this environment variable is not set, Watchtower will use the default time zone: UTC.
-To find out the right value, see [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), find your location and use the value in _TZ Database Name_, e.g _Europe/Rome_. The timezone can alternatively be set by volume mounting your hosts /etc/timezone file. `-v /etc/timezone:/etc/timezone:ro`
+To find out the right value, see [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), find your location and use the value in _TZ Database Name_, e.g _Europe/Rome_. The timezone can alternatively be set by volume mounting your hosts /etc/localtime file. `-v /etc/localtime:/etc/localtime:ro`
 
 ```
             Argument: N/A


### PR DESCRIPTION
The current docs suggests mounting the hosts /etc/timezone into the watchtower container, but that has no effect.

`/etc/localtime` is usually a symlink to `/usr/share/zoneinfo/<contents of /etc/timezone>`, but that symlink has to be created. So whatever is in `/etc/timezone` does not affect the actual tz database being used in watchtower, and since the image is a base image, no service that updates that symlink ever runs.

Instead, this would change the docs to suggest directly mounting the hosts `/etc/localtime` file.

Fixes #876 