### PR TITLE
docs: remove the explicit file name from edit url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Watchtower
 site_url: http://containrrr.github.io/watchtower/
 repo_url: https://github.com/containrrr/watchtower/
-edit_uri: edit/main/docs/index.md
+edit_uri: edit/main/docs/
 theme:
   name: 'material'
   palette:


### PR DESCRIPTION
The current edit buttons in the doc adds an additional `index.md` to the edit URLs:
```
https://github.com/containrrr/watchtower/edit/main/docs/index.md/index.md
```
This just removes the explicit file name to make the URLs relative to the repo default branch.

Follow up from #846