### PR TITLE
fix: move notify URL to trace log

### DIFF
--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -97,7 +97,7 @@ func (n *Notifier) getNotificationTypes(cmd *cobra.Command, levels []log.Level, 
 			log.Fatal("failed to create notification config:", err)
 		}
 
-		println(shoutrrrURL)
+		log.WithField("URL", shoutrrrURL).Trace("created Shoutrrr URL from legacy notifier")
 
 		notifier := newShoutrrrNotifierFromURL(
 			cmd,


### PR DESCRIPTION
When converting legacy notifier configuration to shoutrrr URLs the generated URL is written to stdout (which was probably a development artifact). 
This moves that output to `trace` logging, as it can be useful when explicitly enabled (through `--trace`).

Fixes #906 