### PR TITLE
fix depends on behavior and simplify some of its logic

### DIFF
--- a/internal/actions/check.go
+++ b/internal/actions/check.go
@@ -2,28 +2,47 @@ package actions
 
 import (
 	"fmt"
+	"github.com/containrrr/watchtower/pkg/types"
 	"sort"
 	"time"
 
 	"github.com/containrrr/watchtower/pkg/filters"
 	"github.com/containrrr/watchtower/pkg/sorter"
-	"github.com/sirupsen/logrus"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/containrrr/watchtower/pkg/container"
 )
 
+// CheckForSanity makes sure everything is sane before starting
+func CheckForSanity(client container.Client, filter types.Filter, rollingRestarts bool) error {
+	log.Debug("Making sure everything is sane before starting")
+
+	if rollingRestarts {
+		containers, err := client.ListContainers(filter)
+		if err != nil {
+			return err
+		}
+		for _, c := range containers {
+			if len(c.Links()) > 0 {
+				return fmt.Errorf(
+					"%q is depending on at least one other container. This is not compatible with rolling restarts",
+					c.Name(),
+				)
+			}
+		}
+	}
+	return nil
+}
+
 // CheckForMultipleWatchtowerInstances will ensure that there are not multiple instances of the
 // watchtower running simultaneously. If multiple watchtower containers are detected, this function
 // will stop and remove all but the most recently started container. This behaviour can be bypassed
 // if a scope UID is defined.
 func CheckForMultipleWatchtowerInstances(client container.Client, cleanup bool, scope string) error {
-	awaitDockerClient()
 	containers, err := client.ListContainers(filters.FilterByScope(scope, filters.WatchtowerContainersFilter))
 
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 
@@ -45,14 +64,14 @@ func cleanupExcessWatchtowers(containers []container.Container, client container
 	for _, c := range allContainersExceptLast {
 		if err := client.StopContainer(c, 10*time.Minute); err != nil {
 			// logging the original here as we're just returning a count
-			logrus.WithError(err).Error("Could not stop a previous watchtower instance.")
+			log.WithError(err).Error("Could not stop a previous watchtower instance.")
 			stopErrors++
 			continue
 		}
 
 		if cleanup {
 			if err := client.RemoveImageByID(c.ImageID()); err != nil {
-				logrus.WithError(err).Warning("Could not cleanup watchtower images, possibly because of other watchtowers instances in other scopes.")
+				log.WithError(err).Warning("Could not cleanup watchtower images, possibly because of other watchtowers instances in other scopes.")
 			}
 		}
 	}
@@ -62,9 +81,4 @@ func cleanupExcessWatchtowers(containers []container.Container, client container
 	}
 
 	return nil
-}
-
-func awaitDockerClient() {
-	log.Debug("Sleeping for a second to ensure the docker api client has been properly initialized.")
-	time.Sleep(1 * time.Second)
 }

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -22,8 +22,8 @@ func NewContainer(containerInfo *types.ContainerJSON, imageInfo *types.ImageInsp
 
 // Container represents a running Docker container.
 type Container struct {
-	Linked bool
-	Stale  bool
+	LinkedToRestarting bool
+	Stale              bool
 
 	containerInfo *types.ContainerJSON
 	imageInfo     *types.ImageInspect
@@ -142,7 +142,7 @@ func (c Container) Links() []string {
 // ToRestart return whether the container should be restarted, either because
 // is stale or linked to another stale container.
 func (c Container) ToRestart() bool {
-	return c.Stale || c.Linked
+	return c.Stale || c.LinkedToRestarting
 }
 
 // IsWatchtower returns a boolean flag indicating whether or not the current

--- a/scripts/dependency-test.sh
+++ b/scripts/dependency-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Simulates a container that will always be updated, checking whether it shuts down it's dependencies correctly.
+
 docker rm -f parent || true
 docker rm -f depending || true
 
@@ -12,18 +14,3 @@ docker run -d --name parent $CHANGE
 docker run -d --name depending --link parent $KEEP
 
 go run . --run-once --debug $@
-
-# db<api
-# api-
-# db-
-# db+
-# api+
-
-# ---
-
-# db<api rolling
-# api-
-# api+
-# db-
-# db+
-

--- a/scripts/dependency-test.sh
+++ b/scripts/dependency-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+docker rm -f parent || true
+docker rm -f depending || true
+
+CHANGE=redis:latest
+KEEP=tutum/hello-world
+
+docker tag tutum/hello-world:latest redis:latest
+
+docker run -d --name parent $CHANGE
+docker run -d --name depending --link parent $KEEP
+
+go run . --run-once --debug $@
+
+# db<api
+# api-
+# db-
+# db+
+# api+
+
+# ---
+
+# db<api rolling
+# api-
+# api+
+# db-
+# db+
+


### PR DESCRIPTION
The logic for updating containers in order based on their dependencies had some problems that have been accumulated from various changes, where the full logic wasn't greatly understood.
This PR solves two main reasons why updating linked containers have not been working correctly. It also cleans up the logic and adds more descriptive names to prevent this to happen again.

One scenario that just doesn't make sense is the combination of `rolling-updates` and linked containers, they are now explicitly made mutually exclusive as using them together just causes undefined behaviour,
There could be some additional logic added to do a semi-rolling update instead (which is probably what anyone uses these together would expect to happen), but since that logic is not in place, using them together causes a fatal error for now.

Fatal errors should now also correctly be sent through notifications, since watchtower now waits for pending notifications to be sent before exiting.