### PR TITLE
Allow running periodic updates with enabled HTTP API

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,6 +156,7 @@ func Run(c *cobra.Command, names []string) {
 	runOnce, _ := c.PersistentFlags().GetBool("run-once")
 	enableUpdateAPI, _ := c.PersistentFlags().GetBool("http-api-update")
 	enableMetricsAPI, _ := c.PersistentFlags().GetBool("http-api-metrics")
+	unblockHTTPAPI, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
 	apiToken, _ := c.PersistentFlags().GetString("http-api-token")
 
 	if rollingRestart && monitorOnly {
@@ -180,10 +181,14 @@ func Run(c *cobra.Command, names []string) {
 		logNotifyExit(err)
 	}
 
+	// The lock is shared between the scheduler and the HTTP API. It only allows one update to run at a time.
+	updateLock := make(chan bool, 1)
+	updateLock <- true
+
 	httpAPI := api.New(apiToken)
 
 	if enableUpdateAPI {
-		updateHandler := update.New(func() { runUpdatesWithNotifications(filter) })
+		updateHandler := update.New(func() { runUpdatesWithNotifications(filter) }, updateLock)
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 	}
 
@@ -192,11 +197,11 @@ func Run(c *cobra.Command, names []string) {
 		httpAPI.RegisterHandler(metricsHandler.Path, metricsHandler.Handle)
 	}
 
-	if err := httpAPI.Start(enableUpdateAPI); err != nil {
+	if err := httpAPI.Start(enableUpdateAPI && !unblockHTTPAPI); err != nil {
 		log.Error("failed to start API", err)
 	}
 
-	if err := runUpgradesOnSchedule(c, filter, filterDesc); err != nil {
+	if err := runUpgradesOnSchedule(c, filter, filterDesc, updateLock); err != nil {
 		log.Error(err)
 	}
 
@@ -272,17 +277,19 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 	}
 }
 
-func runUpgradesOnSchedule(c *cobra.Command, filter t.Filter, filtering string) error {
-	tryLockSem := make(chan bool, 1)
-	tryLockSem <- true
+func runUpgradesOnSchedule(c *cobra.Command, filter t.Filter, filtering string, lock chan bool) error {
+	if lock == nil {
+		lock = make(chan bool, 1)
+		lock <- true
+	}
 
 	scheduler := cron.New()
 	err := scheduler.AddFunc(
 		scheduleSpec,
 		func() {
 			select {
-			case v := <-tryLockSem:
-				defer func() { tryLockSem <- v }()
+			case v := <-lock:
+				defer func() { lock <- v }()
 				metric := runUpdatesWithNotifications(filter)
 				metrics.RegisterScan(metric)
 			default:
@@ -313,7 +320,7 @@ func runUpgradesOnSchedule(c *cobra.Command, filter t.Filter, filtering string) 
 	<-interrupt
 	scheduler.Stop()
 	log.Info("Waiting for running update to be finished...")
-	<-tryLockSem
+	<-lock
 	return nil
 }
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -250,6 +250,16 @@ Environment Variable: WATCHTOWER_HTTP_API_TOKEN
              Default: -
 ```
 
+## HTTP API periodic polls
+Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.  
+
+```
+            Argument: --http-api-periodic-polls
+Environment Variable: WATCHTOWER_HTTP_API_PERIODIC_POLLS
+                Type: Boolean
+             Default: false
+```
+
 ## Filter by scope
 Update containers that have a `com.centurylinklabs.watchtower.scope` label set with the same value as the given argument. This enables [running multiple instances](https://containrrr.github.io/watchtower/running-multiple-instances).
 

--- a/docs/http-api-mode.md
+++ b/docs/http-api-mode.md
@@ -28,6 +28,8 @@ services:
       - 8080:8080
 ```
 
+By default, enabling this mode prevents periodic polls (i.e. what is specified using `--interval` or `--schedule`). To run periodic updates regardless, pass `--http-api-periodic-polls`.
+
 Notice that there is an environment variable named WATCHTOWER_HTTP_API_TOKEN. To prevent external services from accidentally triggering image updates, all of the requests have to contain a "Token" field, valued as the token defined in WATCHTOWER_HTTP_API_TOKEN, in their headers. In this case, there is a port bind to the host machine, allowing to request localhost:8080 to reach Watchtower. The following `curl` command would trigger an image update:
 
 ```bash

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -151,6 +151,11 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		viper.GetString("WATCHTOWER_HTTP_API_TOKEN"),
 		"Sets an authentication token to HTTP API requests.")
+	flags.BoolP(
+		"http-api-periodic-polls",
+		"",
+		viper.GetBool("WATCHTOWER_HTTP_API_PERIODIC_POLLS"),
+		"Also run periodic updates (specified with --interval and --schedule) if HTTP API is enabled")
 	// https://no-color.org/
 	flags.BoolP(
 		"no-color",

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -79,3 +79,18 @@ func testGetSecretsFromFiles(t *testing.T, flagName string, expected string) {
 
 	assert.Equal(t, expected, value)
 }
+
+func TestHTTPAPIPeriodicPollsFlag(t *testing.T) {
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+
+	err := cmd.ParseFlags([]string{"--http-api-periodic-polls"})
+	require.NoError(t, err)
+
+	periodicPolls, err := cmd.PersistentFlags().GetBool("http-api-periodic-polls")
+	require.NoError(t, err)
+
+	assert.Equal(t, true, periodicPolls)
+}

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -13,9 +13,13 @@ var (
 )
 
 // New is a factory function creating a new  Handler instance
-func New(updateFn func()) *Handler {
-	lock = make(chan bool, 1)
-	lock <- true
+func New(updateFn func(), updateLock chan bool) *Handler {
+	if updateLock != nil {
+		lock = updateLock
+	} else {
+		lock = make(chan bool, 1)
+		lock <- true
+	}
 
 	return &Handler{
 		fn:   updateFn,


### PR DESCRIPTION
Edit by @simskij: closes #897 

## Motivation
I'd like to run Watchtower both with infrequent periodic updates for images I don't build myself, and have the option to quickly redeploy custom images when they're rebuilt using the HTTP API.
Currently this is not possible, because enabling the HTTP Update API disables scheduled runs.

In theory this would also be possible using multiple Watchtower instances with two scopes, one for "public" images and one for self-built images; however now you need to deal with labels and make sure every container has the correct scope label, which adds unwanted complexity to the setup.
Alternatively you could set up a Cron job to curl `/v1/update` periodically, but this also gets ugly fast given that we're in Docker, and it also splits the "configuration" of Watchtower into two locations. Also the primary purpose for Watchtower is to replace hacky cron jobs to update Docker containers.

Instead, it would be very handy if Watchtower allows running periodic updates and the HTTP API for updates at the same time.

## Changes
Add a new `--http-api-periodic-polls` option with the `WATCHTOWER_HTTP_API_PERIODIC_POLLS` environment variable, defaulting to false.
It has only an effect if the HTTP API mode (`--http-api-update`) is enabled.
If `--http-api-periodic-polls` is passed, the HTTP API doesn't block, and thus allows periodic polls as well (with whatever `--interval` or `--schedule` is given, defaulting to every 24 hours).

I'm open for suggestions to rename this option if you've got something better in mind. I'm not entirely happy with the word "periodic" since it isn't used anywhere else so far. I've considered "scheduled", but it might mislead to think it only affects the `--schedule` option and not `--interval`.

The HTTP API and `runUpgradesOnSchedule()` had separate locks to prevent multiple updates running at the same time.
Since there's the possibility that the schedule triggers while an HTTP API poll is running, or the other way around, I needed to add a global lock. The channel is passed to `runUpgradesOnSchedule()` and `api.update.New()`, which now use this channel for locking instead of making their own.
Both functions still create a new channel if the argument is `nil`, which might simplify future unit testing or other changes.

I've also extended the docs accordingly. If I should clarify or reword something, please do tell.

## Further considerations
I also thought about enabling this behaviour by default (inverting the option and renaming it to`--http-api-only`), since this might be what most people expect, but this could be a "breaking" change, since it differs from the current behaviour.
But if you say it's worth it, I would be happy to do that.