### PR TITLE
config sanity check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -269,6 +269,9 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 		}
 
 		log.Info("Watchtower ", version, "\n", notifs, "\n", filtering, "\n", schedMessage)
+		if log.IsLevelEnabled(log.TraceLevel) {
+			log.Warn("trace level enabled: log will include sensitive information as credentials and tokens")
+		}
 	}
 }
 
@@ -330,8 +333,10 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 	}
 	metricResults, err := actions.Update(client, updateParams)
 	if err != nil {
-		log.Println(err)
+		log.Error(err)
 	}
 	notifier.SendNotification()
+	log.Debugf("Session done: %v scanned, %v updated, %v failed",
+		metricResults.Scanned, metricResults.Updated, metricResults.Failed)
 	return metricResults
 }

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -16,10 +16,13 @@ func CreateMockContainer(id string, name string, image string, created time.Time
 			Image:   image,
 			Name:    name,
 			Created: created.String(),
+			HostConfig: &container2.HostConfig{
+				PortBindings: map[nat.Port][]nat.PortBinding{},
+			},
 		},
 		Config: &container2.Config{
-			Image:  image,
-			Labels: make(map[string]string),
+			Image:        image,
+			Labels:       make(map[string]string),
 			ExposedPorts: map[nat.Port]struct{}{},
 		},
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -258,3 +258,27 @@ func (c Container) HasImageInfo() bool {
 func (c Container) ImageInfo() *types.ImageInspect {
 	return c.imageInfo
 }
+
+// VerifyConfiguration checks the container and image configurations for nil references to make sure
+// that the container can be recreated once deleted
+func (c Container) VerifyConfiguration() error {
+	if c.imageInfo == nil {
+		return errorNoImageInfo
+	}
+
+	containerInfo := c.ContainerInfo()
+	if containerInfo == nil {
+		return errorInvalidConfig
+	}
+
+	containerConfig := containerInfo.Config
+	if containerConfig == nil {
+		return errorInvalidConfig
+	}
+
+	if containerConfig.ExposedPorts == nil {
+		return errorNoExposedPorts
+	}
+
+	return nil
+}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -276,7 +276,12 @@ func (c Container) VerifyConfiguration() error {
 		return errorInvalidConfig
 	}
 
-	if containerConfig.ExposedPorts == nil {
+	hostConfig := containerInfo.HostConfig
+	if hostConfig == nil {
+		return errorInvalidConfig
+	}
+
+	if len(hostConfig.PortBindings) > 0 && containerConfig.ExposedPorts == nil {
 		return errorNoExposedPorts
 	}
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -32,14 +32,14 @@ var _ = Describe("the container", func() {
 			containerKnown := *mockContainerWithImageName("docker.io/prefix/imagename:latest")
 
 			When("warn on head failure is set to \"always\"", func() {
-				c := NewClient(false, false, false, false, false, "always")
+				c := newClientNoAPI(false, false, false, false, false, "always")
 				It("should always return true", func() {
 					Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(BeTrue())
 					Expect(c.WarnOnHeadPullFailed(containerKnown)).To(BeTrue())
 				})
 			})
 			When("warn on head failure is set to \"auto\"", func() {
-				c := NewClient(false, false, false, false, false, "auto")
+				c := newClientNoAPI(false, false, false, false, false, "auto")
 				It("should always return true", func() {
 					Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(BeFalse())
 				})
@@ -48,7 +48,7 @@ var _ = Describe("the container", func() {
 				})
 			})
 			When("warn on head failure is set to \"never\"", func() {
-				c := NewClient(false, false, false, false, false, "never")
+				c := newClientNoAPI(false, false, false, false, false, "never")
 				It("should never return true", func() {
 					Expect(c.WarnOnHeadPullFailed(containerUnknown)).To(BeFalse())
 					Expect(c.WarnOnHeadPullFailed(containerKnown)).To(BeFalse())
@@ -282,9 +282,9 @@ var _ = Describe("the container", func() {
 })
 
 func mockContainerWithImageName(name string) *Container {
-	container := mockContainerWithLabels(nil)
-	container.containerInfo.Config.Image = name
-	return container
+	mockContainer := mockContainerWithLabels(nil)
+	mockContainer.containerInfo.Config.Image = name
+	return mockContainer
 }
 
 func mockContainerWithLinks(links []string) *Container {
@@ -316,4 +316,16 @@ func mockContainerWithLabels(labels map[string]string) *Container {
 		},
 	}
 	return NewContainer(&content, nil)
+}
+
+func newClientNoAPI(pullImages, includeStopped, reviveStopped, removeVolumes, includeRestarting bool, warnOnHeadFailed string) Client {
+	return dockerClient{
+		api:               nil,
+		pullImages:        pullImages,
+		removeVolumes:     removeVolumes,
+		includeStopped:    includeStopped,
+		reviveStopped:     reviveStopped,
+		includeRestarting: includeRestarting,
+		warnOnHeadFailed:  warnOnHeadFailed,
+	}
 }

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -1,0 +1,7 @@
+package container
+
+import "errors"
+
+var errorNoImageInfo = errors.New("no available image info")
+var errorNoExposedPorts = errors.New("exposed port configuration missing")
+var errorInvalidConfig = errors.New("container configuration missing or invalid")

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -3,5 +3,5 @@ package container
 import "errors"
 
 var errorNoImageInfo = errors.New("no available image info")
-var errorNoExposedPorts = errors.New("exposed port configuration missing")
+var errorNoExposedPorts = errors.New("exposed ports does not match port bindings")
 var errorInvalidConfig = errors.New("container configuration missing or invalid")


### PR DESCRIPTION
This will check the container configuration for obvious errors before trying to recreate it, preventing at least some know fault conditions.