### PR TITLE
docs: fix more auto-format casualties

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,9 +25,3 @@ jobs:
             md-toc
       - name: Generate docs
         run: mkdocs gh-deploy --strict
-#      - name: Publish docs
-#        uses: peaceiris/actions-gh-pages@v3
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_dir: ./site
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <p style="text-align: center; margin-left: 1.6rem;">
-  <img src="./images/logo-450px.png" width="450" />
+  <img alt="Logotype depicting a lighthouse" src="./images/logo-450px.png" width="450" />
 </p>
 <h1 align="center">
   Watchtower
@@ -48,15 +48,17 @@ and restart it with the same options that were used when it was deployed initial
 the following command:
 
 === "docker run"
-```bash $ docker run -d \
---name watchtower \
--v /var/run/docker.sock:/var/run/docker.sock \
-containrrr/watchtower
-```
+    ```bash
+    $ docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower
+    ```
 === "docker-compose.yml"
-```yaml version: "3"
-services:
-watchtower:
-image: containrrr/watchtower volumes:
-- /var/run/docker.sock:/var/run/docker.sock
-```
+    ```yaml
+    version: "3"
+    services:
+    watchtower:
+    image: containrrr/watchtower volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    ```

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -31,18 +31,21 @@ These labels can be declared as instructions in a Dockerfile (with some example 
 the `docker run` command line:
 
 === "Dockerfile"
-```docker LABEL com.centurylinklabs.watchtower.lifecycle.pre-check="/sync.sh"
-LABEL com.centurylinklabs.watchtower.lifecycle.pre-update="/dump-data.sh"
-LABEL com.centurylinklabs.watchtower.lifecycle.post-update="/restore-data.sh"
-LABEL com.centurylinklabs.watchtower.lifecycle.post-check="/send-heartbeat.sh"
-```
+    ```docker 
+    LABEL com.centurylinklabs.watchtower.lifecycle.pre-check="/sync.sh"
+    LABEL com.centurylinklabs.watchtower.lifecycle.pre-update="/dump-data.sh"
+    LABEL com.centurylinklabs.watchtower.lifecycle.post-update="/restore-data.sh"
+    LABEL com.centurylinklabs.watchtower.lifecycle.post-check="/send-heartbeat.sh"
+    ```
+
 === "docker run"
-```bash docker run -d \
---label=com.centurylinklabs.watchtower.lifecycle.pre-check="/sync.sh" \
---label=com.centurylinklabs.watchtower.lifecycle.pre-update="/dump-data.sh" \
---label=com.centurylinklabs.watchtower.lifecycle.post-update="/restore-data.sh" \
-someimage --label=com.centurylinklabs.watchtower.lifecycle.post-check="/send-heartbeat.sh" \
-```
+    ```bash 
+    docker run -d \
+    --label=com.centurylinklabs.watchtower.lifecycle.pre-check="/sync.sh" \
+    --label=com.centurylinklabs.watchtower.lifecycle.pre-update="/dump-data.sh" \
+    --label=com.centurylinklabs.watchtower.lifecycle.post-update="/restore-data.sh" \
+    someimage --label=com.centurylinklabs.watchtower.lifecycle.post-check="/send-heartbeat.sh" \
+    ```
 
 ### Timeouts
 The timeout for all lifecycle commands is 60 seconds. After that, a timeout will

--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -103,43 +103,40 @@ Use the dockerfile below to build the [amazon-ecr-credential-helper](https://git
 in a volume that may be mounted onto your watchtower container.
 
 1.  Create the Dockerfile (contents below):
-
-   ```Dockerfile
-   FROM golang:latest
-   
-   ENV CGO_ENABLED 0
-   ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
-   
-   RUN go get -u $REPO
-   
-   RUN rm /go/bin/docker-credential-ecr-login
-   
-   RUN go build \
+    ```Dockerfile
+    FROM golang:latest
+    
+    ENV CGO_ENABLED 0
+    ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+    
+    RUN go get -u $REPO
+    
+    RUN rm /go/bin/docker-credential-ecr-login
+    
+    RUN go build \
      -o /go/bin/docker-credential-ecr-login \
      /go/src/$REPO
-   
-   WORKDIR /go/bin/
-   ```
+    
+    WORKDIR /go/bin/
+    ```
 
 2.  Use the following commands to build the aws-ecr-dock-cred-helper and store it's output in a volume:
-
-   ```bash
-   # Create a volume to store the command (once built)
-   docker volume create helper 
-   
-   # Build the container
-   docker build -t aws-ecr-dock-cred-helper .
-   
-   # Build the command and store it in the new volume in the /go/bin directory.
-   docker run  -d --rm --name aws-cred-helper --volume helper:/go/bin aws-ecr-dock-cred-helper
-   
-   ```
+    ```bash
+    # Create a volume to store the command (once built)
+    docker volume create helper 
+    
+    # Build the container
+    docker build -t aws-ecr-dock-cred-helper .
+    
+    # Build the command and store it in the new volume in the /go/bin directory.
+    docker run  -d --rm --name aws-cred-helper \
+      --volume helper:/go/bin aws-ecr-dock-cred-helper
+    ```
 
 3.  Create a configuration file for docker, and store it in $HOME/.docker/config.json (replace the <AWS_ACCOUNT_ID>
    placeholders with your AWS Account ID):
-
-   ```json
-   {
+    ```json
+    {
        "credsStore" : "ecr-login",
        "HttpHeaders" : {
          "User-Agent" : "Docker-Client/19.03.1 (XXXXXX)"
@@ -150,11 +147,10 @@ in a volume that may be mounted onto your watchtower container.
        "credHelpers": {
          "<AWS_ACCOUNT_ID>.dkr.ecr.us-west-1.amazonaws.com" : "ecr-login"
        }
-   }
-   ```
+    }
+    ```
 
 4.  Create a docker-compose file (as an example) to help launch the container:
- 
     ```yaml
     version: "3.4"
     services:


### PR DESCRIPTION
Fixes more of the auto-format issues that slipped by in #936 

Format on commit - great for go, horrible for markdown!