### PR TITLE
docs: remove stray paragraph in notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -112,8 +112,6 @@ networks:
 
 ### Slack
 
-If watchtower is monitoring the same Docker daemon under which the watchtower container itself is running (i.e. if you volume-mounted _/var/run/docker.sock_ into the watchtower container) then it has the ability to update itself. If a new version of the _containrrr/watchtower_ image is pushed to the Docker Hub, your watchtower will pull down the new image and restart itself automatically.
-
 To receive notifications in Slack, add `slack` to the `--notifications` option or the `WATCHTOWER_NOTIFICATIONS` environment variable.
 
 Additionally, you should set the Slack webhook URL using the `--notification-slack-hook-url` option or the `WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL` environment variable. This option can also reference a file, in which case the contents of the file are used.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,6 @@
+## Updating Watchtower
+
+If watchtower is monitoring the same Docker daemon under which the watchtower container itself is running (i.e. if you 
+volume-mounted `/var/run/docker.sock` into the watchtower container) then it has the ability to update itself.  
+If a new version of the `containrrr/watchtower` image is pushed to the Docker Hub, your watchtower will pull down the 
+new image and restart itself automatically.


### PR DESCRIPTION
the paragraph from the slack documentation were originally it's own section in the readme:
https://github.com/containrrr/watchtower/blob/985a9220993d09f0bb0232a558447773ac6006dd/README.md#L406-L409

I added it back as well, since it could still be a useful section to have and it's definitely something that's missing from the docs right now. Could do with some more explaining and tips (pinning older version?)

fixes #946