### PR TITLE
Use golang:1.15 in ECR credential helper example

### DIFF
--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -104,8 +104,9 @@ in a volume that may be mounted onto your watchtower container.
 
 1.  Create the Dockerfile (contents below):
     ```Dockerfile
-    FROM golang:1.15
+    FROM golang:1.16
     
+    ENV GO111MODULE off
     ENV CGO_ENABLED 0
     ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
     

--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -104,7 +104,7 @@ in a volume that may be mounted onto your watchtower container.
 
 1.  Create the Dockerfile (contents below):
     ```Dockerfile
-    FROM golang:latest
+    FROM golang:1.15
     
     ENV CGO_ENABLED 0
     ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login


### PR DESCRIPTION
The example Dockerfile provided for ecr-credential-helper no longer builds on `golang:1.16`.

This PR simply pins the version specified in the Dockerfile to `golang:1.15`:

```
$ cat Dockerfile
FROM golang:latest

ENV CGO_ENABLED 0
ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login

RUN go get -u $REPO

RUN rm /go/bin/docker-credential-ecr-login

RUN go build \
 -o /go/bin/docker-credential-ecr-login \
 /go/src/$REPO

WORKDIR /go/bin/
ubuntu@ip-10-0-3-95:~/credential-helper$ docker build -t aws-ecr-dock-cred-helper .
Sending build context to Docker daemon  2.048kB
Step 1/7 : FROM golang:latest
 ---> 96129f3766cf
Step 2/7 : ENV CGO_ENABLED 0
 ---> Using cache
 ---> 905ba7abe5da
Step 3/7 : ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 ---> Using cache
 ---> 7812b2c262c2
Step 4/7 : RUN go get -u $REPO
 ---> Using cache
 ---> d598e79b0d71
Step 5/7 : RUN rm /go/bin/docker-credential-ecr-login
 ---> Using cache
 ---> 0cbf53304a18
Step 6/7 : RUN go build  -o /go/bin/docker-credential-ecr-login  /go/src/$REPO
 ---> Running in 2dad4197b560
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
The command '/bin/sh -c go build  -o /go/bin/docker-credential-ecr-login  /go/src/$REPO' returned a non-zero
code: 1
```
```
$ cat Dockerfile
FROM golang:1.15

ENV CGO_ENABLED 0
ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login

RUN go get -u $REPO

RUN rm /go/bin/docker-credential-ecr-login

RUN go build \
 -o /go/bin/docker-credential-ecr-login \
 /go/src/$REPO

WORKDIR /go/bin/
$ docker build -t aws-ecr-dock-cred-helper .
Sending build context to Docker daemon  2.048kB
Step 1/7 : FROM golang:1.15
 ---> e5b4455acc93
Step 2/7 : ENV CGO_ENABLED 0
 ---> Using cache
 ---> 32df66289405
Step 3/7 : ENV REPO github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 ---> Using cache
 ---> 3ff787805cb3
Step 4/7 : RUN go get -u $REPO
 ---> Using cache
 ---> 7117a30722f5
Step 5/7 : RUN rm /go/bin/docker-credential-ecr-login
 ---> Using cache
 ---> 2780ccb85ab8
Step 6/7 : RUN go build  -o /go/bin/docker-credential-ecr-login  /go/src/$REPO
 ---> Using cache
 ---> f848f437fa25
Step 7/7 : WORKDIR /go/bin/
 ---> Using cache
 ---> 58cd6fc9e9f1
Successfully built 58cd6fc9e9f1
Successfully tagged aws-ecr-dock-cred-helper:latest
```