### PR TITLE
Custom User Agent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 VERSION=$(git describe --tags)
 echo "Building $VERSION..."
-go build -o watchtower -ldflags "-X github.com/containrrr/watchtower/cmd.version=$VERSION"
+go build -o watchtower -ldflags "-X github.com/containrrr/watchtower/internal/meta.Version=$VERSION"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/containrrr/watchtower/internal/meta"
 	"math"
 	"os"
 	"os/signal"
@@ -39,7 +40,6 @@ var (
 	rollingRestart bool
 	scope          string
 	// Set on build using ldflags
-	version = "v0.0.0-unknown"
 )
 
 var rootCmd = NewRootCommand()
@@ -273,7 +273,7 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 			notifs = "Using notifications: " + notifList
 		}
 
-		log.Info("Watchtower ", version, "\n", notifs, "\n", filtering, "\n", schedMessage)
+		log.Info("Watchtower ", meta.Version, "\n", notifs, "\n", filtering, "\n", schedMessage)
 		if log.IsLevelEnabled(log.TraceLevel) {
 			log.Warn("trace level enabled: log will include sensitive information as credentials and tokens")
 		}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -10,7 +10,7 @@ build:
     - arm
     - arm64
   ldflags:
-    - -s -w -X github.com/containrrr/watchtower/cmd.version={{.Version}}
+    - -s -w -X github.com/containrrr/watchtower/internal/meta.Version={{.Version}}
 archives:
   - 
     name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -1,0 +1,13 @@
+package meta
+
+var (
+	// Version is the compile-time set version of Watchtower
+	Version = "v0.0.0-unknown"
+
+	// UserAgent is the http client identifier derived from Version
+	UserAgent string
+)
+
+func init() {
+	UserAgent = "Watchtower/" + Version
+}

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/containrrr/watchtower/internal/meta"
 	"github.com/containrrr/watchtower/pkg/registry/auth"
 	"github.com/containrrr/watchtower/pkg/registry/manifest"
 	"github.com/containrrr/watchtower/pkg/types"
@@ -86,6 +87,7 @@ func GetDigest(url string, token string) (string, error) {
 	client := &http.Client{Transport: tr}
 
 	req, _ := http.NewRequest("HEAD", url, nil)
+	req.Header.Set("User-Agent", meta.UserAgent)
 
 	if token != "" {
 		logrus.WithField("token", token).Trace("Setting request token")


### PR DESCRIPTION
Set a custom `User-Agent` header in the http client requests.
The value would be `Watchtower/1.3.0` (with the appropriate version of course).

Fixes #986 