### PR TITLE
ci: build dev with script

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.15
       - name: Build
-        run: go build -v ./...
+        run: ./build.sh
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
latest-dev package is not built with version set and displays `v0.0.0-unknown`