### PR TITLE
docs: Remove broken badge and fix docker-compose snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
   [![Circle CI](https://circleci.com/gh/containrrr/watchtower.svg?style=shield)](https://circleci.com/gh/containrrr/watchtower)
   [![codecov](https://codecov.io/gh/containrrr/watchtower/branch/main/graph/badge.svg)](https://codecov.io/gh/containrrr/watchtower)
   [![GoDoc](https://godoc.org/github.com/containrrr/watchtower?status.svg)](https://godoc.org/github.com/containrrr/watchtower)
-  [![Microbadger](https://images.microbadger.com/badges/image/containrrr/watchtower.svg)](https://microbadger.com/images/containrrr/watchtower)
   [![Go Report Card](https://goreportcard.com/badge/github.com/containrrr/watchtower)](https://goreportcard.com/report/github.com/containrrr/watchtower)
   [![latest version](https://img.shields.io/github/tag/containrrr/watchtower.svg)](https://github.com/containrrr/watchtower/releases)
   [![Apache-2.0 License](https://img.shields.io/github/license/containrrr/watchtower.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,6 @@
   <a href="https://godoc.org/github.com/containrrr/watchtower">
     <img alt="GoDoc" src="https://godoc.org/github.com/containrrr/watchtower?status.svg" />
   </a>
-  <a href="https://microbadger.com/images/containrrr/watchtower">
-    <img alt="Microbadger" src="https://images.microbadger.com/badges/image/containrrr/watchtower.svg" />
-  </a>
   <a href="https://goreportcard.com/report/github.com/containrrr/watchtower">
     <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/containrrr/watchtower" />
   </a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,8 +55,8 @@ the following command:
     ```yaml
     version: "3"
     services:
-    watchtower:
-    image: containrrr/watchtower
-    volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+      watchtower:
+        image: containrrr/watchtower
+        volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,5 +58,5 @@ the following command:
       watchtower:
         image: containrrr/watchtower
         volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+          - /var/run/docker.sock:/var/run/docker.sock
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ the following command:
     version: "3"
     services:
     watchtower:
-    image: containrrr/watchtower 
+    image: containrrr/watchtower
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     ```


### PR DESCRIPTION
1.) This PR removes the microbadger badge. It's not resolving, and the project is shutdown:

<img width="878" alt="image" src="https://user-images.githubusercontent.com/3526705/126084827-c9c33452-4e29-4772-8e25-e847afc53cff.png">


https://twitter.com/microscaling/status/1361054926399557644
https://web.archive.org/web/20210409135814/https://microbadger.com/shutdown

2.) Remove a trailing space.  I think this is causing the snippet to now show up as expected on the [quickstart guide](https://containrrr.dev/watchtower/#quick_start) with `image` and `volumes` being on the same line:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/3526705/126084870-f75a03c5-de3b-4504-b7f0-1bccbffe3489.png">

3.) Adjusts the indentation of the docker-compose snippet

