### PR TITLE
Prefer long flags in quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 With watchtower you can update the running version of your containerized app simply by pushing a new image to the Docker Hub or your own image registry. Watchtower will pull down your new image, gracefully shut down your existing container and restart it with the same options that were used when it was deployed initially. Run the watchtower container with the following command:
 
 ```
-$ docker run -d \
+$ docker run --detach \
     --name watchtower \
-    -v /var/run/docker.sock:/var/run/docker.sock \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
     containrrr/watchtower
 ```
 


### PR DESCRIPTION
`--detach` is clearer (to a new Docker user) than `-d`. Similarly `--volume` is clearer than `-v`.

Motivation: https://changelog.com/posts/use-long-flags-when-scripting
Referred to: https://docs.docker.com/engine/reference/commandline/run/