### PR TITLE
Fix for certain problems on Synology devices

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -244,7 +244,10 @@ func (c Container) runtimeConfig() *dockercontainer.Config {
 		}
 	}
 	for p := range c.containerInfo.HostConfig.PortBindings {
-		config.ExposedPorts[p] = struct{}{}
+		// config.ExposedPorts isn't reliably in sync with HostConfig.PortBindings, so we can't assign directly to map without checking
+		if _, ok := config.ExposedPorts[p]; ok {
+			config.ExposedPorts[p] = struct{}{}
+		}
 	}
 
 	config.Image = c.ImageName()
@@ -296,10 +299,6 @@ func (c Container) VerifyConfiguration() error {
 	hostConfig := containerInfo.HostConfig
 	if hostConfig == nil {
 		return errorInvalidConfig
-	}
-
-	if len(hostConfig.PortBindings) > 0 && containerConfig.ExposedPorts == nil {
-		return errorNoExposedPorts
 	}
 
 	return nil


### PR DESCRIPTION
Avoid 'assignment to entry in nil map' when `*container.Config.ExposedPorts` is not filled

These logs come directly from my Synology device (with the code from this PR running):
```
time="2021-09-04T20:05:34Z" level=debug msg="Trying to load authentication credentials." container=/homeassistant image="homeassistant/home-assistant:stable"
time="2021-09-04T20:05:34Z" level=debug msg="No credentials for homeassistant found" config_file=/config.json
time="2021-09-04T20:05:34Z" level=debug msg="Got image name: homeassistant/home-assistant:stable"
time="2021-09-04T20:05:34Z" level=debug msg="Checking if pull is needed" container=/homeassistant image="homeassistant/home-assistant:stable"
time="2021-09-04T20:05:34Z" level=debug msg="Building challenge URL" URL="https://index.docker.io/v2/"
time="2021-09-04T20:05:35Z" level=debug msg="Got response to challenge request" header="Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\"" status="401 Unauthorized"
time="2021-09-04T20:05:35Z" level=debug msg="Checking challenge header content" realm="https://auth.docker.io/token" service=registry.docker.io
time="2021-09-04T20:05:35Z" level=debug msg="Setting scope for auth token" image=homeassistant/home-assistant scope="repository:homeassistant/home-assistant:pull"
time="2021-09-04T20:05:35Z" level=debug msg="No credentials found."
time="2021-09-04T20:05:35Z" level=debug msg="Parsing image ref" host=index.docker.io image=homeassistant/home-assistant normalized="docker.io/homeassistant/home-assistant:stable" tag=stable
time="2021-09-04T20:05:35Z" level=debug msg="Doing a HEAD request to fetch a digest" url="https://index.docker.io/v2/homeassistant/home-assistant/manifests/stable"
time="2021-09-04T20:05:35Z" level=debug msg="Found a remote digest to compare with" remote="sha256:43b39af7c9c63b933ba4ed17c226c97111c39a4cb379e444099292bdeedfbaff"
time="2021-09-04T20:05:35Z" level=debug msg=Comparing local="sha256:8f5fd806376b78183851cd408885bf27e82f7d9de7638c8cfcef838a6e7c31ea" remote="sha256:43b39af7c9c63b933ba4ed17c226c97111c39a4cb379e444099292bdeedfbaff"
time="2021-09-04T20:05:35Z" level=debug msg="Digests did not match, doing a pull."
time="2021-09-04T20:05:35Z" level=debug msg="Pulling image" container=/homeassistant image="homeassistant/home-assistant:stable"
time="2021-09-04T20:06:41Z" level=info msg="Found new homeassistant/home-assistant:stable image (16caae5dfda5)"
.........
time="2021-09-04T20:06:43Z" level=info msg="Stopping /homeassistant (ddc0d725a628) with SIGTERM"
time="2021-09-04T20:06:50Z" level=debug msg="Removing container ddc0d725a628"
time="2021-09-04T20:06:58Z" level=debug msg="This is the watchtower container /tender_banach"
time="2021-09-04T20:06:58Z" level=info msg="Creating /homeassistant"
time="2021-09-04T20:07:00Z" level=debug msg="Starting container /homeassistant (0fdc56784bd2)"
time="2021-09-04T20:07:02Z" level=debug msg="Session done: 4 scanned, 1 updated, 0 failed"
```