### PR TITLE
Add a user option for lifecycle hooks

### DIFF
--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -50,6 +50,12 @@ the `docker run` command line:
     someimage --label=com.centurylinklabs.watchtower.lifecycle.post-check="/send-heartbeat.sh" \
     ```
 
+### Specifying a user for lifecycle hooks
+
+The lifecycle hooks all support a '.user' extension to specify a user to run the command with, for example:""
+
+com.centurylinklabs.watchtower.lifecycle.pre-check.user="myuser"
+
 ### Timeouts
 The timeout for all lifecycle commands is 60 seconds. After that, a timeout will
 occur, forcing Watchtower to continue the update loop.

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -75,7 +75,7 @@ func (client MockClient) GetContainer(_ t.ContainerID) (container.Container, err
 }
 
 // ExecuteCommand is a mock method
-func (client MockClient) ExecuteCommand(_ t.ContainerID, command string, _ int) (SkipUpdate bool, err error) {
+func (client MockClient) ExecuteCommand(_ t.ContainerID, command string, user string, _ int) (SkipUpdate bool, err error) {
 	switch command {
 	case "/PreUpdateReturn0.sh":
 		return false, nil

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -370,8 +370,8 @@ func (client dockerClient) ExecuteCommand(containerID t.ContainerID, command str
 		Cmd:    []string{"sh", "-c", command},
 	}
 
-	if user!="" {
-		execConfig.User=user
+	if user != "" {
+		execConfig.User = user
 	}
 
 	exec, err := client.api.ContainerExecCreate(bg, string(containerID), execConfig)

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -31,7 +31,7 @@ type Client interface {
 	StartContainer(Container) (t.ContainerID, error)
 	RenameContainer(Container, string) error
 	IsContainerStale(Container) (stale bool, latestImage t.ImageID, err error)
-	ExecuteCommand(containerID t.ContainerID, command string, timeout int) (SkipUpdate bool, err error)
+	ExecuteCommand(containerID t.ContainerID, command string, user string, timeout int) (SkipUpdate bool, err error)
 	RemoveImageByID(t.ImageID) error
 	WarnOnHeadPullFailed(container Container) bool
 }
@@ -359,7 +359,7 @@ func (client dockerClient) RemoveImageByID(id t.ImageID) error {
 	return err
 }
 
-func (client dockerClient) ExecuteCommand(containerID t.ContainerID, command string, timeout int) (SkipUpdate bool, err error) {
+func (client dockerClient) ExecuteCommand(containerID t.ContainerID, command string, user string, timeout int) (SkipUpdate bool, err error) {
 	bg := context.Background()
 	clog := log.WithField("containerID", containerID)
 
@@ -368,6 +368,10 @@ func (client dockerClient) ExecuteCommand(containerID t.ContainerID, command str
 		Tty:    true,
 		Detach: false,
 		Cmd:    []string{"sh", "-c", command},
+	}
+
+	if user!="" {
+		execConfig.User=user
 	}
 
 	exec, err := client.api.ContainerExecCreate(bg, string(containerID), execConfig)

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -137,7 +137,7 @@ var _ = Describe("the client", func() {
 				defer logrus.SetOutput(origOut)
 				logrus.SetOutput(logbuf)
 
-				_, err := client.ExecuteCommand("ex-cont-id", "exec-cmd", 1)
+				_, err := client.ExecuteCommand("ex-cont-id", "exec-cmd", "", 1)
 				Expect(err).NotTo(HaveOccurred())
 				// Note: Since Execute requires opening up a raw TCP stream to the daemon for the output, this will fail
 				// when using the mock API server. Regardless of the outcome, the log should include the container ID

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -142,6 +142,11 @@ var _ = Describe("the client", func() {
 				// Note: Since Execute requires opening up a raw TCP stream to the daemon for the output, this will fail
 				// when using the mock API server. Regardless of the outcome, the log should include the container ID
 				Eventually(logbuf).Should(gbytes.Say(`containerID="?ex-cont-id"?`))
+
+				_, err := client.ExecuteCommand("ex-cont-id", "exec-cmd", "myuser", 1)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(logbuf).Should(gbytes.Say(`containerID="?ex-cont-id"?`))
+
 			})
 		})
 	})

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -12,14 +12,12 @@ const (
 	postCheckLabel        = "com.centurylinklabs.watchtower.lifecycle.post-check"
 	preUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.pre-update"
 	postUpdateLabel       = "com.centurylinklabs.watchtower.lifecycle.post-update"
-	preCheckUserLabel     = "com.centurylinklabs.watchtower.lifecycle.pre-check.user"	
+	preCheckUserLabel     = "com.centurylinklabs.watchtower.lifecycle.pre-check.user"
 	postCheckUserLabel    = "com.centurylinklabs.watchtower.lifecycle.post-check.user"
 	preUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
-	preUpdateUserLabel	  = "com.centurylinklabs.watchtower.lifecycle.pre-update.user"
+	preUpdateUserLabel    = "com.centurylinklabs.watchtower.lifecycle.pre-update.user"
 	postUpdateUserLabel   = "com.centurylinklabs.watchtower.lifecycle.post-update.user"
-	
 )
-
 
 // GetLifecyclePreCheckCommand returns the pre-check command set in the container metadata or an empty string
 func (c Container) GetLifecyclePreCheckCommand() string {
@@ -41,7 +39,6 @@ func (c Container) GetLifecyclePostUpdateCommand() string {
 	return c.getLabelValueOrEmpty(postUpdateLabel)
 }
 
-
 // GetLifecyclePreCheckUser returns the pre-check user set in the container metadata or an empty string
 func (c Container) GetLifecyclePreCheckUser() string {
 	return c.getLabelValueOrEmpty(preCheckUserLabel)
@@ -61,8 +58,6 @@ func (c Container) GetLifecyclePreUpdateUser() string {
 func (c Container) GetLifecyclePostUpdateUser() string {
 	return c.getLabelValueOrEmpty(postUpdateUserLabel)
 }
-
-
 
 // ContainsWatchtowerLabel takes a map of labels and values and tells
 // the consumer whether it contains a valid watchtower instance label

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -42,22 +42,22 @@ func (c Container) GetLifecyclePostUpdateCommand() string {
 }
 
 
-// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+// GetLifecyclePreCheckUser returns the pre-check user set in the container metadata or an empty string
 func (c Container) GetLifecyclePreCheckUser() string {
 	return c.getLabelValueOrEmpty(preCheckUserLabel)
 }
 
-// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+// GetLifecyclePostCheckUser returns the post-check user in the container metadata or an empty string
 func (c Container) GetLifecyclePostCheckUser() string {
 	return c.getLabelValueOrEmpty(postCheckUserLabel)
 }
 
-// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+// GetLifecyclePreUpdateUser returns the pre-update user set in the container metadata or an empty string
 func (c Container) GetLifecyclePreUpdateUser() string {
 	return c.getLabelValueOrEmpty(preUpdateUserLabel)
 }
 
-// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+// GetLifecyclePostUpdateUser returns the post-update set in the container metadata or an empty string
 func (c Container) GetLifecyclePostUpdateUser() string {
 	return c.getLabelValueOrEmpty(postUpdateUserLabel)
 }

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -12,8 +12,14 @@ const (
 	postCheckLabel        = "com.centurylinklabs.watchtower.lifecycle.post-check"
 	preUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.pre-update"
 	postUpdateLabel       = "com.centurylinklabs.watchtower.lifecycle.post-update"
+	preCheckUserLabel     = "com.centurylinklabs.watchtower.lifecycle.pre-check.user"	
+	postCheckUserLabel    = "com.centurylinklabs.watchtower.lifecycle.post-check.user"
 	preUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
+	preUpdateUserLabel	  = "com.centurylinklabs.watchtower.lifecycle.pre-update.user"
+	postUpdateUserLabel   = "com.centurylinklabs.watchtower.lifecycle.post-update.user"
+	
 )
+
 
 // GetLifecyclePreCheckCommand returns the pre-check command set in the container metadata or an empty string
 func (c Container) GetLifecyclePreCheckCommand() string {
@@ -34,6 +40,29 @@ func (c Container) GetLifecyclePreUpdateCommand() string {
 func (c Container) GetLifecyclePostUpdateCommand() string {
 	return c.getLabelValueOrEmpty(postUpdateLabel)
 }
+
+
+// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+func (c Container) GetLifecyclePreCheckUser() string {
+	return c.getLabelValueOrEmpty(preCheckUserLabel)
+}
+
+// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+func (c Container) GetLifecyclePostCheckUser() string {
+	return c.getLabelValueOrEmpty(postCheckUserLabel)
+}
+
+// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+func (c Container) GetLifecyclePreUpdateUser() string {
+	return c.getLabelValueOrEmpty(preUpdateUserLabel)
+}
+
+// GetPreCheckUserLabel returns the pre-check command set in the container metadata or an empty string
+func (c Container) GetLifecyclePostUpdateUser() string {
+	return c.getLabelValueOrEmpty(postUpdateUserLabel)
+}
+
+
 
 // ContainsWatchtowerLabel takes a map of labels and values and tells
 // the consumer whether it contains a valid watchtower instance label

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -31,9 +31,9 @@ func ExecutePostChecks(client container.Client, params types.UpdateParams) {
 // ExecutePreCheckCommand tries to run the pre-check lifecycle hook for a single container.
 func ExecutePreCheckCommand(client container.Client, container container.Container) {
 	command := container.GetLifecyclePreCheckCommand()
-	user	:= container.GetLifecyclePreCheckUser()
+	user := container.GetLifecyclePreCheckUser()
 	fields := log.Fields{
-		"user":     user,
+		"user":      user,
 		"container": container.Name(),
 	}
 	clog := log.WithFields(fields)
@@ -52,9 +52,9 @@ func ExecutePreCheckCommand(client container.Client, container container.Contain
 // ExecutePostCheckCommand tries to run the post-check lifecycle hook for a single container.
 func ExecutePostCheckCommand(client container.Client, container container.Container) {
 	command := container.GetLifecyclePostCheckCommand()
-	user	:= container.GetLifecyclePostCheckUser()
+	user := container.GetLifecyclePostCheckUser()
 	fields := log.Fields{
-		"user":     user,
+		"user":      user,
 		"container": container.Name(),
 	}
 	clog := log.WithFields(fields)
@@ -74,13 +74,13 @@ func ExecutePostCheckCommand(client container.Client, container container.Contai
 func ExecutePreUpdateCommand(client container.Client, container container.Container) (SkipUpdate bool, err error) {
 	timeout := container.PreUpdateTimeout()
 	command := container.GetLifecyclePreUpdateCommand()
-	user	:= container.GetLifecyclePreUpdateUser()
+	user := container.GetLifecyclePreUpdateUser()
 	fields := log.Fields{
-		"user":     user,
+		"user":      user,
 		"container": container.Name(),
 	}
 	clog := log.WithFields(fields)
-	
+
 	if len(command) == 0 {
 		clog.Debug("No pre-update command supplied. Skipping")
 		return false, nil
@@ -105,13 +105,12 @@ func ExecutePostUpdateCommand(client container.Client, newContainerID types.Cont
 	}
 
 	command := newContainer.GetLifecyclePostUpdateCommand()
-	user	:= newContainer.GetLifecyclePostUpdateUser()
+	user := newContainer.GetLifecyclePostUpdateUser()
 	fields := log.Fields{
-		"user":     user,
+		"user":      user,
 		"container": newContainer.Name(),
 	}
 	clog := log.WithFields(fields)
-	
 
 	if len(command) == 0 {
 		clog.Debug("No post-update command supplied. Skipping")

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -30,9 +30,13 @@ func ExecutePostChecks(client container.Client, params types.UpdateParams) {
 
 // ExecutePreCheckCommand tries to run the pre-check lifecycle hook for a single container.
 func ExecutePreCheckCommand(client container.Client, container container.Container) {
-	clog := log.WithField("container", container.Name())
 	command := container.GetLifecyclePreCheckCommand()
 	user	:= container.GetLifecyclePreCheckUser()
+	fields := log.Fields{
+		"user":     user,
+		"container": container.Name(),
+	}
+	clog := log.WithFields(fields)
 	if len(command) == 0 {
 		clog.Debug("No pre-check command supplied. Skipping")
 		return
@@ -47,9 +51,13 @@ func ExecutePreCheckCommand(client container.Client, container container.Contain
 
 // ExecutePostCheckCommand tries to run the post-check lifecycle hook for a single container.
 func ExecutePostCheckCommand(client container.Client, container container.Container) {
-	clog := log.WithField("container", container.Name())
 	command := container.GetLifecyclePostCheckCommand()
 	user	:= container.GetLifecyclePostCheckUser()
+	fields := log.Fields{
+		"user":     user,
+		"container": container.Name(),
+	}
+	clog := log.WithFields(fields)
 	if len(command) == 0 {
 		clog.Debug("No post-check command supplied. Skipping")
 		return
@@ -67,8 +75,12 @@ func ExecutePreUpdateCommand(client container.Client, container container.Contai
 	timeout := container.PreUpdateTimeout()
 	command := container.GetLifecyclePreUpdateCommand()
 	user	:= container.GetLifecyclePreUpdateUser()
-	clog := log.WithField("container", container.Name())
-
+	fields := log.Fields{
+		"user":     user,
+		"container": container.Name(),
+	}
+	clog := log.WithFields(fields)
+	
 	if len(command) == 0 {
 		clog.Debug("No pre-update command supplied. Skipping")
 		return false, nil
@@ -91,10 +103,16 @@ func ExecutePostUpdateCommand(client container.Client, newContainerID types.Cont
 		log.WithField("containerID", newContainerID.ShortID()).Error(err)
 		return
 	}
-	clog := log.WithField("container", newContainer.Name())
 
 	command := newContainer.GetLifecyclePostUpdateCommand()
 	user	:= newContainer.GetLifecyclePostUpdateUser()
+	fields := log.Fields{
+		"user":     user,
+		"container": newContainer.Name(),
+	}
+	clog := log.WithFields(fields)
+	
+
 	if len(command) == 0 {
 		clog.Debug("No post-update command supplied. Skipping")
 		return

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -32,13 +32,14 @@ func ExecutePostChecks(client container.Client, params types.UpdateParams) {
 func ExecutePreCheckCommand(client container.Client, container container.Container) {
 	clog := log.WithField("container", container.Name())
 	command := container.GetLifecyclePreCheckCommand()
+	user	:= container.GetLifecyclePreCheckUser()
 	if len(command) == 0 {
 		clog.Debug("No pre-check command supplied. Skipping")
 		return
 	}
 
 	clog.Debug("Executing pre-check command.")
-	_, err := client.ExecuteCommand(container.ID(), command, 1)
+	_, err := client.ExecuteCommand(container.ID(), command, user, 1)
 	if err != nil {
 		clog.Error(err)
 	}
@@ -48,13 +49,14 @@ func ExecutePreCheckCommand(client container.Client, container container.Contain
 func ExecutePostCheckCommand(client container.Client, container container.Container) {
 	clog := log.WithField("container", container.Name())
 	command := container.GetLifecyclePostCheckCommand()
+	user	:= container.GetLifecyclePostCheckUser()
 	if len(command) == 0 {
 		clog.Debug("No post-check command supplied. Skipping")
 		return
 	}
 
 	clog.Debug("Executing post-check command.")
-	_, err := client.ExecuteCommand(container.ID(), command, 1)
+	_, err := client.ExecuteCommand(container.ID(), command, user, 1)
 	if err != nil {
 		clog.Error(err)
 	}
@@ -64,6 +66,7 @@ func ExecutePostCheckCommand(client container.Client, container container.Contai
 func ExecutePreUpdateCommand(client container.Client, container container.Container) (SkipUpdate bool, err error) {
 	timeout := container.PreUpdateTimeout()
 	command := container.GetLifecyclePreUpdateCommand()
+	user	:= container.GetLifecyclePreUpdateUser()
 	clog := log.WithField("container", container.Name())
 
 	if len(command) == 0 {
@@ -77,7 +80,7 @@ func ExecutePreUpdateCommand(client container.Client, container container.Contai
 	}
 
 	clog.Debug("Executing pre-update command.")
-	return client.ExecuteCommand(container.ID(), command, timeout)
+	return client.ExecuteCommand(container.ID(), command, user, timeout)
 }
 
 // ExecutePostUpdateCommand tries to run the post-update lifecycle hook for a single container.
@@ -91,13 +94,14 @@ func ExecutePostUpdateCommand(client container.Client, newContainerID types.Cont
 	clog := log.WithField("container", newContainer.Name())
 
 	command := newContainer.GetLifecyclePostUpdateCommand()
+	user	:= newContainer.GetLifecyclePostUpdateUser()
 	if len(command) == 0 {
 		clog.Debug("No post-update command supplied. Skipping")
 		return
 	}
 
 	clog.Debug("Executing post-update command.")
-	_, err = client.ExecuteCommand(newContainerID, command, 1)
+	_, err = client.ExecuteCommand(newContainerID, command, user, 1)
 
 	if err != nil {
 		clog.Error(err)

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -62,4 +62,8 @@ type Container interface {
 	GetLifecyclePostCheckCommand() string
 	GetLifecyclePreUpdateCommand() string
 	GetLifecyclePostUpdateCommand() string
+	GetLifecyclePreCheckUser() string
+	GetLifecyclePostCheckUser() string
+	GetLifecyclePreUpdateUser() string
+	GetLifecyclePostUpdateUser() string
 }


### PR DESCRIPTION
Hi all,

This pull request adds a user option for the lifecycle hooks, which enables them to be run under a particular user for example:

com.centurylinklabs.watchtower.lifecycle.pre-check.user="myuser"

that value is then passed to the docker exec command invocation for the given hook.

Thanks!