### PR TITLE
feat: use a more specific error type for no container info

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -285,7 +285,7 @@ func (c Container) VerifyConfiguration() error {
 
 	containerInfo := c.ContainerInfo()
 	if containerInfo == nil {
-		return errorInvalidConfig
+		return errorNoContainerInfo
 	}
 
 	containerConfig := containerInfo.Config

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -23,7 +23,7 @@ var _ = Describe("the container", func() {
 				c := mockContainerWithPortBindings()
 				c.containerInfo = nil
 				err := c.VerifyConfiguration()
-				Expect(err).To(Equal(errorInvalidConfig))
+				Expect(err).To(Equal(errorNoContainerInfo))
 			})
 		})
 		When("verifying a container with no config", func() {

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -3,5 +3,6 @@ package container
 import "errors"
 
 var errorNoImageInfo = errors.New("no available image info")
+var errorNoContainerInfo = errors.New("no available container info")
 var errorNoExposedPorts = errors.New("exposed ports does not match port bindings")
 var errorInvalidConfig = errors.New("container configuration missing or invalid")


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

This PR adds a new error type to when `ContainerInfo` comes back nil while verifying the configuration. It currently returns `errorInvalidConfig`, this change will return `errorNoContainerInfo` instead. Similar to how we return `errorNoImageInfo` when `ImageInfo` is nil.