### PR TITLE
feat: improve session result logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -364,7 +364,10 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 	}
 	notifier.SendNotification(result)
 	metricResults := metrics.NewMetric(result)
-	log.Debugf("Session done: %v scanned, %v updated, %v failed",
-		metricResults.Scanned, metricResults.Updated, metricResults.Failed)
+	notifications.LocalLog.WithFields(log.Fields{
+		"Scanned": metricResults.Scanned,
+		"Updated": metricResults.Updated,
+		"Failed":  metricResults.Failed,
+	}).Info("Session done")
 	return metricResults
 }

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -152,7 +152,7 @@ func (n *shoutrrrTypeNotifier) sendEntries(entries []*log.Entry, report t.Report
 		go func() {
 			if err != nil {
 				LocalLog.WithError(err).Fatal("Notification template error")
-			} else {
+			} else if len(n.Urls) > 1 {
 				LocalLog.Info("Skipping notification due to empty message")
 			}
 		}()


### PR DESCRIPTION
- logs the session result as an info level message without notification instead of debug
- does not log that no notification was sent if there are no notifications enabled

Fixes #1122 

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
