### PR TITLE
Fix docker-compose syntax in quick-start. GH #1105

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,20 +46,20 @@ the following command:
 
 === "docker run"
 
-  ```bash
-  $ docker run -d \
-  --name watchtower \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower
-  ```
+    ```bash
+    $ docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    containrrr/watchtower
+    ```
 
 === "docker-compose.yml"
 
-  ```yaml
-  version: "3"
-  services:
-    watchtower:
-      image: containrrr/watchtower
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-  ```
+    ```yaml
+    version: "3"
+    services:
+      watchtower:
+        image: containrrr/watchtower
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,18 +45,21 @@ and restart it with the same options that were used when it was deployed initial
 the following command:
 
 === "docker run"
-    ```bash
-    $ docker run -d \
-    --name watchtower \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    containrrr/watchtower
-    ```
+
+  ```bash
+  $ docker run -d \
+  --name watchtower \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower
+  ```
+
 === "docker-compose.yml"
-    ```yaml
-    version: "3"
-    services:
-      watchtower:
-        image: containrrr/watchtower
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
-    ```
+
+  ```yaml
+  version: "3"
+  services:
+    watchtower:
+      image: containrrr/watchtower
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+  ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,8 @@ markdown_extensions:
         user: containrrr
         repo: watchtower
     - pymdownx.saneheaders
-    - pymdownx.tabbed
+    - pymdownx.tabbed:
+        alternate_style: true 
 nav:
    - 'Home': 'index.md'
    - 'Introduction': 'introduction.md'


### PR DESCRIPTION
Result after my changes. Although the tabbed feature is not working for me locally.

![docker-compose-volumes-watchtower](https://user-images.githubusercontent.com/6141390/146692718-32ec4791-f634-4661-a2da-d1b2f33352e3.png)