### PR TITLE
fix: move invalid token to log field

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -29,10 +29,6 @@ func (api *API) RequireToken(fn http.HandlerFunc) http.HandlerFunc {
 		auth := r.Header.Get("Authorization")
 		want := fmt.Sprintf("Bearer %s", api.Token)
 		if auth != want {
-			log.WithFields(log.Fields{
-				"got":      fmt.Sprintf("%q", auth),
-				"expected": want,
-			}).Tracef("Invalid Authorization header")
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const tokenMissingMsg = "api token is empty or has not been set. exiting"
@@ -28,8 +29,10 @@ func (api *API) RequireToken(fn http.HandlerFunc) http.HandlerFunc {
 		auth := r.Header.Get("Authorization")
 		want := fmt.Sprintf("Bearer %s", api.Token)
 		if auth != want {
-			log.Tracef("Invalid Authorization header \"%s\"", auth)
-			log.Tracef("Expected Authorization header to be \"%s\"", want)
+			log.WithFields(log.Fields{
+				"got":      auth,
+				"expected": want,
+			}).Tracef("Invalid Authorization header")
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,7 +30,7 @@ func (api *API) RequireToken(fn http.HandlerFunc) http.HandlerFunc {
 		want := fmt.Sprintf("Bearer %s", api.Token)
 		if auth != want {
 			log.WithFields(log.Fields{
-				"got":      auth,
+				"got":      fmt.Sprintf("%q", auth),
 				"expected": want,
 			}).Tracef("Invalid Authorization header")
 			w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Prevents potential log manipulation. Probably not a realistic concern, but fixing it is easier than dismissing the warnings.

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
