### PR TITLE
fix: add missing portmap when needed

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 )
 
 // NewContainer returns a new Container instance instantiated with the
@@ -191,24 +192,22 @@ func (c Container) PreUpdateTimeout() int {
 
 // PostUpdateTimeout checks whether a container has a specific timeout set
 // for how long the post-update command is allowed to run. This value is expressed
- // either as an integer, in minutes, or as 0 which will allow the command/script
- // to run indefinitely. Users should be cautious with the 0 option, as that
- // could result in watchtower waiting forever.
- func (c Container) PostUpdateTimeout() int {
- 	var minutes int
- 	var err error
+// either as an integer, in minutes, or as 0 which will allow the command/script
+// to run indefinitely. Users should be cautious with the 0 option, as that
+// could result in watchtower waiting forever.
+func (c Container) PostUpdateTimeout() int {
+	var minutes int
+	var err error
 
- 	val := c.getLabelValueOrEmpty(postUpdateTimeoutLabel)
+	val := c.getLabelValueOrEmpty(postUpdateTimeoutLabel)
 
- 	minutes, err = strconv.Atoi(val)
- 	if err != nil || val == "" {
- 		return 1
- 	}
+	minutes, err = strconv.Atoi(val)
+	if err != nil || val == "" {
+		return 1
+	}
 
- 	return minutes
- }
-
-
+	return minutes
+}
 
 // StopSignal returns the custom stop signal (if any) that is encoded in the
 // container's metadata. If the container has not specified a custom stop
@@ -319,8 +318,10 @@ func (c Container) VerifyConfiguration() error {
 		return errorInvalidConfig
 	}
 
+	// Instead of returning an error here, we just create an empty map
+	// This should allow for updating containers where the exposed ports are missing
 	if len(hostConfig.PortBindings) > 0 && containerConfig.ExposedPorts == nil {
-		return errorNoExposedPorts
+		containerConfig.ExposedPorts = make(map[nat.Port]struct{})
 	}
 
 	return nil

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -50,11 +50,13 @@ var _ = Describe("the container", func() {
 			})
 		})
 		When("verifying a container with port bindings, but no exposed ports", func() {
-			It("should return an error", func() {
+			It("should make the config compatible with updating", func() {
 				c := mockContainerWithPortBindings("80/tcp")
 				c.containerInfo.Config.ExposedPorts = nil
-				err := c.VerifyConfiguration()
-				Expect(err).To(Equal(errorNoExposedPorts))
+				Expect(c.VerifyConfiguration()).To(Succeed())
+
+				Expect(c.containerInfo.Config.ExposedPorts).ToNot(BeNil())
+				Expect(c.containerInfo.Config.ExposedPorts).To(BeEmpty())
 			})
 		})
 		When("verifying a container with port bindings and exposed ports is non-nil", func() {


### PR DESCRIPTION
Alternative to #1068, allowing containers with nil exposed ports to be updated by watchtower. This has not been tested on an actual Synology device, but should not have any impact on non-synology docker instances.

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
