### PR TITLE
Fix typo on --http-api-update environment variable and add warning note for --http-api-periodic-polls

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -241,7 +241,7 @@ For details see [HTTP API](https://containrrr.dev/watchtower/http-api-mode).
 
 ```text
             Argument: --http-api-update
-Environment Variable: WATCHTOWER_HTTP_API
+Environment Variable: WATCHTOWER_HTTP_API_UPDATE
                 Type: Boolean
              Default: false
 ```

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -257,6 +257,10 @@ Environment Variable: WATCHTOWER_HTTP_API_TOKEN
 ```
 
 ## HTTP API periodic polls
+
+!!! warning
+This argument is not currently available in the 1.3.0 release.
+
 Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.  
 
 ```text

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -257,10 +257,6 @@ Environment Variable: WATCHTOWER_HTTP_API_TOKEN
 ```
 
 ## HTTP API periodic polls
-
-!!! warning
-This argument is not currently available in the 1.3.0 release.
-
 Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.  
 
 ```text


### PR DESCRIPTION
Minor docs issue, but the --http-api-update parameter has a typo on it's env var equivalent. Using the env var provided by the docs will not enable the HTTP API update only endpoint and you'll get a 404.

~~In addition due to #1127, the docs are currently listing a parameter which isn't actually available in any official release currently, so I thought a warning may be useful until a new release is made, which can then be removed.~~

Thanks!
