### PR TITLE
Initial work to add Update Delay feature

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,6 +134,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	reviveStopped, _ := f.GetBool("revive-stopped")
 	removeVolumes, _ := f.GetBool("remove-volumes")
 	warnOnHeadPullFailed, _ := f.GetString("warn-on-head-failure")
+	updateDelay, _ := f.GetDuration("update-delay")
 
 	if monitorOnly && noPull {
 		log.Warn("Using `WATCHTOWER_NO_PULL` and `WATCHTOWER_MONITOR_ONLY` simultaneously might lead to no action being taken at all. If this is intentional, you may safely ignore this message.")
@@ -146,6 +147,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		removeVolumes,
 		includeRestarting,
 		warnOnHeadPullFailed,
+		updateDelay,
 	)
 
 	notifier = notifications.NewNotifier(cmd)

--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -94,3 +94,8 @@ func (client MockClient) IsContainerStale(_ container.Container) (bool, t.ImageI
 func (client MockClient) WarnOnHeadPullFailed(_ container.Container) bool {
 	return true
 }
+
+// always return true in the mock
+func (client MockClient) OldEnoughImage(_ container.Container, _ t.ImageID) bool {
+	return true
+}

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -34,8 +34,9 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 
 	for i, targetContainer := range containers {
 		stale, newestImage, err := client.IsContainerStale(targetContainer)
-		shouldUpdate := stale && !params.NoRestart && !params.MonitorOnly && !targetContainer.IsMonitorOnly()
-		if err == nil && shouldUpdate {
+		oldEnough := client.OldEnoughImage(targetContainer, newestImage)
+		shouldUpdate := stale && !params.NoRestart && !params.MonitorOnly && !targetContainer.IsMonitorOnly() && oldEnough
+		if err == nil && shouldUpdate && oldEnough {
 			// Check to make sure we have all the necessary information for recreating the container
 			err = targetContainer.VerifyConfiguration()
 			// If the image information is incomplete and trace logging is enabled, log it for further diagnosis
@@ -58,6 +59,7 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 			progress.AddScanned(targetContainer, newestImage)
 		}
 		containers[i].Stale = stale
+		containers[i].OldEnoughImage = oldEnough
 
 		if stale {
 			staleCount++
@@ -74,7 +76,7 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 	var containersToUpdate []container.Container
 	if !params.MonitorOnly {
 		for _, c := range containers {
-			if !c.IsMonitorOnly() {
+			if !c.IsMonitorOnly() && c.OldEnoughImage {
 				containersToUpdate = append(containersToUpdate, c)
 				progress.MarkForUpdate(c.ID())
 			}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -45,6 +45,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		viper.GetDuration("WATCHTOWER_TIMEOUT"),
 		"Timeout before a container is forcefully stopped")
 
+	flags.DurationP(
+		"update-delay",
+		"",
+		viper.GetDuration("WATCHTOWER_UPDATE_DELAY"),
+		"Delay an image pull until it is atleast this old")
+
 	flags.BoolP(
 		"no-pull",
 		"",
@@ -335,6 +341,7 @@ func SetDefaults() {
 	viper.SetDefault("DOCKER_API_VERSION", DockerAPIMinVersion)
 	viper.SetDefault("WATCHTOWER_POLL_INTERVAL", day)
 	viper.SetDefault("WATCHTOWER_TIMEOUT", time.Second*10)
+	viper.SetDefault("WATCHTOWER_UPDATE_DELAY", 0)
 	viper.SetDefault("WATCHTOWER_NOTIFICATIONS", []string{})
 	viper.SetDefault("WATCHTOWER_NOTIFICATIONS_LEVEL", "info")
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT", 25)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -26,6 +26,7 @@ func NewContainer(containerInfo *types.ContainerJSON, imageInfo *types.ImageInsp
 type Container struct {
 	LinkedToRestarting bool
 	Stale              bool
+	OldEnoughImage     bool
 
 	containerInfo *types.ContainerJSON
 	imageInfo     *types.ImageInspect

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -1,18 +1,19 @@
 package container
 
 const (
-	watchtowerLabel       = "com.centurylinklabs.watchtower"
-	signalLabel           = "com.centurylinklabs.watchtower.stop-signal"
-	enableLabel           = "com.centurylinklabs.watchtower.enable"
-	monitorOnlyLabel      = "com.centurylinklabs.watchtower.monitor-only"
-	dependsOnLabel        = "com.centurylinklabs.watchtower.depends-on"
-	zodiacLabel           = "com.centurylinklabs.zodiac.original-image"
-	scope                 = "com.centurylinklabs.watchtower.scope"
-	preCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.pre-check"
-	postCheckLabel        = "com.centurylinklabs.watchtower.lifecycle.post-check"
-	preUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.pre-update"
-	postUpdateLabel       = "com.centurylinklabs.watchtower.lifecycle.post-update"
-	preUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
+	watchtowerLabel        = "com.centurylinklabs.watchtower"
+	signalLabel            = "com.centurylinklabs.watchtower.stop-signal"
+	enableLabel            = "com.centurylinklabs.watchtower.enable"
+	monitorOnlyLabel       = "com.centurylinklabs.watchtower.monitor-only"
+	dependsOnLabel         = "com.centurylinklabs.watchtower.depends-on"
+	updateDelayLabel       = "com.centurylinklabs.watchtower.update-delay"
+	zodiacLabel            = "com.centurylinklabs.zodiac.original-image"
+	scope                  = "com.centurylinklabs.watchtower.scope"
+	preCheckLabel          = "com.centurylinklabs.watchtower.lifecycle.pre-check"
+	postCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.post-check"
+	preUpdateLabel         = "com.centurylinklabs.watchtower.lifecycle.pre-update"
+	postUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.post-update"
+	preUpdateTimeoutLabel  = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
 	postUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.post-update-timeout"
 )
 


### PR DESCRIPTION
Work not complete but my initial attempt at adding an update delay feature

Lets you not update an image if X amount of time has passed since the new image was created

Note that this is all based off the Created Time field from the image. So if an image is published with an incorrect date it could be considered old enough.

Further work to be done but I'm looking for initial feedback before I spend more time on it.

Closes #426 properly 