### PR TITLE
feat: regex container name filtering

### DIFF
--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -3,6 +3,7 @@ package filters
 import (
 	t "github.com/containrrr/watchtower/pkg/types"
 	"strings"
+	"regexp"
 )
 
 // WatchtowerContainersFilter filters only watchtower containers
@@ -19,7 +20,9 @@ func FilterByNames(names []string, baseFilter t.Filter) t.Filter {
 
 	return func(c t.FilterableContainer) bool {
 		for _, name := range names {
-			if (name == c.Name()) || (name == c.Name()[1:]) {
+			match, _ := (regexp.MatchString(name, c.Name()))
+			match1, _ := (regexp.MatchString(name, c.Name()[1:]))
+			if (name == c.Name()) || (name == c.Name()[1:]) || match || match1 {
 				return baseFilter(c)
 			}
 		}

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -47,6 +47,28 @@ func TestFilterByNames(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestFilterByNamesRegex(t *testing.T) {
+	names := []string{`ba(b|ll)oon`}
+
+	filter := FilterByNames(names, NoFilter)
+	assert.NotNil(t, filter)
+
+	container := new(mocks.FilterableContainer)
+	container.On("Name").Return("balloon")
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Name").Return("spoon")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Name").Return("baboonious")
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+}
+
 func TestFilterByEnableLabel(t *testing.T) {
 	filter := FilterByEnableLabel(NoFilter)
 	assert.NotNil(t, filter)
@@ -68,8 +90,7 @@ func TestFilterByEnableLabel(t *testing.T) {
 }
 
 func TestFilterByScope(t *testing.T) {
-	var scope string
-	scope = "testscope"
+	scope := "testscope"
 
 	filter := FilterByScope(scope, NoFilter)
 	assert.NotNil(t, filter)
@@ -111,11 +132,12 @@ func TestFilterByDisabledLabel(t *testing.T) {
 }
 
 func TestBuildFilter(t *testing.T) {
-	var names []string
-	names = append(names, "test")
+	names := []string{"test", "valid"}
 
 	filter, desc := BuildFilter(names, false, "")
 	assert.Contains(t, desc, "test")
+	assert.Contains(t, desc, "or")
+	assert.Contains(t, desc, "valid")
 
 	container := new(mocks.FilterableContainer)
 	container.On("Name").Return("Invalid")


### PR DESCRIPTION
This small change allows the use of re2 regex in the container name filter parameter

I'm currently running this in my environment with the following cmdline
```--cleanup --interval 21600 -d \/[^k][^8][^s][^_][\S]+```

This prevents containers belonging to K8s from being auto updated as there is no way to enforce labels correctly in K8s.

I've been running this since end of January and had no problems so far - thought it would be nice to PR this.