### PR TITLE
feat(notifications): add general notification delay

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -26,6 +26,7 @@ comma-separated list of values to the `--notifications` option
 
 -   `--notifications-level` (env. `WATCHTOWER_NOTIFICATIONS_LEVEL`): Controls the log level which is used for the notifications. If omitted, the default log level is `info`. Possible values are: `panic`, `fatal`, `error`, `warn`, `info`, `debug` or `trace`.
 -   `--notifications-hostname` (env. `WATCHTOWER_NOTIFICATIONS_HOSTNAME`): Custom hostname specified in subject/title. Useful to override the operating system hostname.
+-   `--notifications-delay` (env. `WATCHTOWER_NOTIFICATION_DELAY`): Delay before sending notifications expressed in seconds.
 -   Watchtower will post a notification every time it is started. This behavior [can be changed](https://containrrr.github.io/watchtower/arguments/#without_sending_a_startup_message) with an argument.
 
 ## Available services

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -184,6 +184,12 @@ func RegisterNotificationFlags(rootCmd *cobra.Command) {
 		viper.GetString("WATCHTOWER_NOTIFICATIONS_LEVEL"),
 		"The log level used for sending notifications. Possible values: panic, fatal, error, warn, info or debug")
 
+	flags.IntP(
+		"notifications-delay",
+		"",
+		viper.GetInt("WATCHTOWER_NOTIFICATIONS_DELAY"),
+		"Delay before sending notifications, expressed in seconds")
+
 	flags.StringP(
 		"notifications-hostname",
 		"",

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -95,9 +95,8 @@ func GetDelay(c *cobra.Command, legacyDelay time.Duration) time.Duration {
 	delay, _ := c.PersistentFlags().GetInt("notifications-delay")
 	if delay > 0 {
 		return time.Duration(delay) * time.Second
-	} else {
-		return time.Duration(0)
 	}
+	return time.Duration(0)
 }
 
 // GetTitle returns a common notification title with hostname appended

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -82,13 +82,13 @@ var _ = Describe("notifications", func() {
 			})
 		})
 		When("legacy delay and delay is defined", func() {
-			It("should use the specified legacy delay", func() {
+			It("should use the specified legacy delay and ignore the specified delay", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)
 
 				err := command.ParseFlags([]string{
 					"--notifications-delay",
-					"5",
+					"0",
 				})
 				Expect(err).NotTo(HaveOccurred())
 				delay := notifications.GetDelay(command, time.Duration(7)*time.Second)

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -55,7 +55,7 @@ var _ = Describe("notifications", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)
 
-				delay := notifications.GetDelay(command)
+				delay := notifications.GetDelay(command, time.Duration(0))
 				Expect(delay).To(Equal(time.Duration(0)))
 			})
 		})
@@ -69,8 +69,30 @@ var _ = Describe("notifications", func() {
 					"5",
 				})
 				Expect(err).NotTo(HaveOccurred())
-				delay := notifications.GetDelay(command)
+				delay := notifications.GetDelay(command, time.Duration(0))
 				Expect(delay).To(Equal(time.Duration(5) * time.Second))
+			})
+		})
+		When("legacy delay is defined", func() {
+			It("should use the specified legacy delay", func() {
+				command := cmd.NewRootCommand()
+				flags.RegisterNotificationFlags(command)
+				delay := notifications.GetDelay(command, time.Duration(5)*time.Second)
+				Expect(delay).To(Equal(time.Duration(5) * time.Second))
+			})
+		})
+		When("legacy delay and delay is defined", func() {
+			It("should use the specified legacy delay", func() {
+				command := cmd.NewRootCommand()
+				flags.RegisterNotificationFlags(command)
+
+				err := command.ParseFlags([]string{
+					"--notifications-delay",
+					"5",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				delay := notifications.GetDelay(command, time.Duration(7)*time.Second)
+				Expect(delay).To(Equal(time.Duration(7) * time.Second))
 			})
 		})
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
This PR will add the possibility to define a delay before sending a notification in the new notification system with `notifications-delay`. The legacy delay for emails (`notification-email-delay`) will still work and overwrite the general delay.