### PR TITLE
fix: testing for flag files on windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+BINFILE=watchtower
+if [ -n "$MSYSTEM" ]; then
+    BINFILE=watchtower.exe
+fi
 VERSION=$(git describe --tags)
 echo "Building $VERSION..."
-go build -o watchtower -ldflags "-X github.com/containrrr/watchtower/internal/meta.Version=$VERSION"
+go build -o $BINFILE -ldflags "-X github.com/containrrr/watchtower/internal/meta.Version=$VERSION"

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -458,9 +459,13 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) {
 }
 
 func isFile(s string) bool {
-	_, err := os.Stat(s)
-	if os.IsNotExist(err) {
+	firstColon := strings.IndexRune(s, ':')
+	if firstColon != 1 && firstColon != -1 {
+		// If the string contains a ':', but it's not the second character, it's probably not a file
+		// and will cause a fatal error on windows if stat'ed
+		// This still allows for paths that start with 'c:\' etc.
 		return false
 	}
-	return true
+	_, err := os.Stat(s)
+	return !errors.Is(err, os.ErrNotExist)
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestEnvConfig_Defaults(t *testing.T) {
+	// Unset testing environments own variables, since those are not what is under test
+	os.Unsetenv("DOCKER_TLS_VERIFY")
+	os.Unsetenv("DOCKER_HOST")
+
 	cmd := new(cobra.Command)
 	SetDefaults()
 	RegisterDockerFlags(cmd)
@@ -93,4 +97,9 @@ func TestHTTPAPIPeriodicPollsFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, true, periodicPolls)
+}
+
+func TestIsFile(t *testing.T) {
+	assert.False(t, isFile("https://google.com"), "an URL should never be considered a file")
+	assert.True(t, isFile(os.Args[0]), "the currently running binary path should always be considered a file")
 }


### PR DESCRIPTION
Since testing for file names that contain a `:` (and not being a legitimate volume letter path, like `c:`) causes a fatal error on windows, this skips checking such strings and always considers them being literal flag values.

Fixes #1245