### PR TITLE
feat(api): supports custom port with 8080 as default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,7 @@ func Run(c *cobra.Command, names []string) {
 	filter, filterDesc := filters.BuildFilter(names, enableLabel, scope)
 	runOnce, _ := c.PersistentFlags().GetBool("run-once")
 	enableUpdateAPI, _ := c.PersistentFlags().GetBool("http-api-update")
-	httpAPIPort, _ := c.PersistentFlags().GetString("http-api-port")
+	httpAPIPort, _ := c.PersistentFlags().GetInt("http-api-port")
 
 	enableMetricsAPI, _ := c.PersistentFlags().GetBool("http-api-metrics")
 	unblockHTTPAPI, _ := c.PersistentFlags().GetBool("http-api-periodic-polls")
@@ -270,8 +270,8 @@ func formatDuration(d time.Duration) string {
 func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 	noStartupMessage, _ := c.PersistentFlags().GetBool("no-startup-message")
 	enableUpdateAPI, _ := c.PersistentFlags().GetBool("http-api-update")
-	apiPort, _ := c.PersistentFlags().GetString("http-api-port")
-	if apiPort == "" {
+	apiPort, _ := c.PersistentFlags().GetInt("http-api-port")
+	if apiPort == 0 {
 		apiPort = api.DefaultPort
 	}
 
@@ -306,7 +306,7 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 	}
 
 	if enableUpdateAPI {
-		startupLog.Infof("The HTTP API is enabled at :%s.", apiPort)
+		startupLog.Infof("The HTTP API is enabled at :%d.", apiPort)
 	}
 
 	if !noStartupMessage {

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -262,7 +262,7 @@ Sets port to HTTP API server.
 ```text
             Argument: --http-api-port
 Environment Variable: WATCHTOWER_HTTP_API_PORT
-                Type: String
+                Type: Int
              Default: 8080
 ```
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -256,6 +256,16 @@ Environment Variable: WATCHTOWER_HTTP_API_TOKEN
              Default: -
 ```
 
+## HTTP API PORT
+Sets port to HTTP API server.
+
+```text
+            Argument: --http-api-port
+Environment Variable: WATCHTOWER_HTTP_API_PORT
+                Type: String
+             Default: 8080
+```
+
 ## HTTP API periodic polls
 Keep running periodic updates if the HTTP API mode is enabled, otherwise the HTTP API would prevent periodic polls.  
 

--- a/docs/http-api-mode.md
+++ b/docs/http-api-mode.md
@@ -30,7 +30,7 @@ services:
 
 By default, enabling this mode prevents periodic polls (i.e. what is specified using `--interval` or `--schedule`). To run periodic updates regardless, pass `--http-api-periodic-polls`.
 
-Notice that there is an environment variable named WATCHTOWER_HTTP_API_TOKEN. To prevent external services from accidentally triggering image updates, all of the requests have to contain a "Token" field, valued as the token defined in WATCHTOWER_HTTP_API_TOKEN, in their headers. In this case, there is a port bind to the host machine, allowing to request localhost:8080 to reach Watchtower. The following `curl` command would trigger an image update:
+Notice that there is an environment variable named WATCHTOWER_HTTP_API_TOKEN. To prevent external services from accidentally triggering image updates, all of the requests have to contain a "Token" field, valued as the token defined in WATCHTOWER_HTTP_API_TOKEN, in their headers. In this case, there is a port bind to the host machine, allowing to request localhost:[port(default: 8080)](arguments.md#http-api-port) to reach Watchtower. The following `curl` command would trigger an image update:
 
 ```bash
 curl -H "Authorization: Bearer mytoken" localhost:8080/v1/update

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,7 +5,7 @@
 Metrics can be used to track how Watchtower behaves over time.
 
 To use this feature, you have to set an [API token](arguments.md#http-api-token) and [enable the metrics API](arguments.md#http-api-metrics),
-as well as creating a port mapping for your container for port `8080`.
+as well as creating a port mapping for your container for port [API port](arguments.md#http-api-port).
 
 The metrics API endpoint is `/v1/metrics`.
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -151,6 +151,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		viper.GetString("WATCHTOWER_HTTP_API_TOKEN"),
 		"Sets an authentication token to HTTP API requests.")
+	flags.StringP(
+		"http-api-port",
+		"",
+		viper.GetString("WATCHTOWER_HTTP_API_PORT"),
+		"Sets port to HTTP API server.")
+
 	flags.BoolP(
 		"http-api-periodic-polls",
 		"",

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -151,10 +151,10 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		viper.GetString("WATCHTOWER_HTTP_API_TOKEN"),
 		"Sets an authentication token to HTTP API requests.")
-	flags.StringP(
+	flags.IntP(
 		"http-api-port",
 		"",
-		viper.GetString("WATCHTOWER_HTTP_API_PORT"),
+		viper.GetInt("WATCHTOWER_HTTP_API_PORT"),
 		"Sets port to HTTP API server.")
 
 	flags.BoolP(
@@ -352,6 +352,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT", 25)
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG", "")
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
+	viper.SetDefault("WATCHTOWER_HTTP_API_PORT", 8080)
 }
 
 // EnvConfig translates the command-line options into environment variables

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,6 +8,7 @@ import (
 )
 
 const tokenMissingMsg = "api token is empty or has not been set. exiting"
+const DefaultPort = "8080"
 
 // API is the http server responsible for serving the HTTP API endpoints
 type API struct {
@@ -50,7 +51,7 @@ func (api *API) RegisterHandler(path string, handler http.Handler) {
 }
 
 // Start the API and serve over HTTP. Requires an API Token to be set.
-func (api *API) Start(block bool) error {
+func (api *API) Start(block bool, port string) error {
 
 	if !api.hasHandlers {
 		log.Debug("Watchtower HTTP API skipped.")
@@ -62,15 +63,18 @@ func (api *API) Start(block bool) error {
 	}
 
 	if block {
-		runHTTPServer()
+		runHTTPServer(port)
 	} else {
 		go func() {
-			runHTTPServer()
+			runHTTPServer(port)
 		}()
 	}
 	return nil
 }
 
-func runHTTPServer() {
-	log.Fatal(http.ListenAndServe(":8080", nil))
+func runHTTPServer(port string) {
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -75,8 +75,5 @@ func (api *API) Start(block bool, port int) error {
 }
 
 func runHTTPServer(port int) {
-	if port == 0 {
-		port = 8080
-	}
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,7 +10,7 @@ import (
 const tokenMissingMsg = "api token is empty or has not been set. exiting"
 
 // DefaultPort is the default port used for the http server
-const DefaultPort = "8080"
+const DefaultPort = 8080
 
 // API is the http server responsible for serving the HTTP API endpoints
 type API struct {
@@ -53,7 +53,7 @@ func (api *API) RegisterHandler(path string, handler http.Handler) {
 }
 
 // Start the API and serve over HTTP. Requires an API Token to be set.
-func (api *API) Start(block bool, port string) error {
+func (api *API) Start(block bool, port int) error {
 
 	if !api.hasHandlers {
 		log.Debug("Watchtower HTTP API skipped.")
@@ -74,9 +74,9 @@ func (api *API) Start(block bool, port string) error {
 	return nil
 }
 
-func runHTTPServer(port string) {
-	if port == "" {
-		port = "8080"
+func runHTTPServer(port int) {
+	if port == 0 {
+		port = 8080
 	}
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,6 +8,8 @@ import (
 )
 
 const tokenMissingMsg = "api token is empty or has not been set. exiting"
+
+// DefaultPort is the default port used for the http server
 const DefaultPort = "8080"
 
 // API is the http server responsible for serving the HTTP API endpoints


### PR DESCRIPTION
This is all about the custom port for the "http api server"
