### PR TITLE
feat(http): optional query parameter to update only containers of a specified image

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,7 +189,7 @@ func Run(c *cobra.Command, names []string) {
 	httpAPI := api.New(apiToken)
 
 	if enableUpdateAPI {
-		updateHandler := update.New(func() { runUpdatesWithNotifications(filter) }, updateLock)
+		updateHandler := update.New(func(tags []string) { runUpdatesWithNotifications(filters.FilterByImageTag(tags, filter)) }, updateLock)
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 		// If polling isn't enabled the scheduler is never started and
 		// we need to trigger the startup messages manually.
@@ -293,7 +293,7 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 		startupLog.Info("Scheduling first run: " + sched.Format("2006-01-02 15:04:05 -0700 MST"))
 		startupLog.Info("Note that the first check will be performed in " + until)
 	} else if runOnce, _ := c.PersistentFlags().GetBool("run-once"); runOnce {
-			startupLog.Info("Running a one time update.")
+		startupLog.Info("Running a one time update.")
 	} else {
 		startupLog.Info("Periodic runs are not enabled.")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -189,7 +189,7 @@ func Run(c *cobra.Command, names []string) {
 	httpAPI := api.New(apiToken)
 
 	if enableUpdateAPI {
-		updateHandler := update.New(func(tags []string) { runUpdatesWithNotifications(filters.FilterByImageTag(tags, filter)) }, updateLock)
+		updateHandler := update.New(func(images []string) { runUpdatesWithNotifications(filters.FilterByImage(images, filter)) }, updateLock)
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 		// If polling isn't enabled the scheduler is never started and
 		// we need to trigger the startup messages manually.

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -48,8 +48,9 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	imageQueries, found := r.URL.Query()["image"]
 	if found {
 		for _, image := range imageQueries {
-			images = strings.Split(image, ",")
+			images = append(images, strings.Split(image, ",")...)
 		}
+
 	} else {
 		images = nil
 	}

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -45,7 +46,7 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	var images []string
 	if r.URL.Query().Has("image") {
-		images = []string{r.URL.Query().Get("image")}
+		images = strings.Split(r.URL.Query().Get("image"), ",")
 	} else {
 		images = nil
 	}

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -45,8 +45,10 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var images []string
-	if r.URL.Query().Has("image") {
-		images = strings.Split(r.URL.Query().Get("image"), ",")
+	if imageQueries, found := r.URL.Query()["image"] {
+		for _, image := range imageQueries {
+			images = append(images, strings.Split(image, ","))
+		}
 	} else {
 		images = nil
 	}

--- a/pkg/api/update/update.go
+++ b/pkg/api/update/update.go
@@ -45,9 +45,10 @@ func (handle *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var images []string
-	if imageQueries, found := r.URL.Query()["image"] {
+	imageQueries, found := r.URL.Query()["image"]
+	if found {
 		for _, image := range imageQueries {
-			images = append(images, strings.Split(image, ","))
+			images = strings.Split(image, ",")
 		}
 	} else {
 		images = nil

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -327,6 +327,7 @@ func (c Container) VerifyConfiguration() error {
 	return nil
 }
 
+// Image returns the image tag of the container as reported by the runtime config
 func (c Container) Image() string {
 	return c.runtimeConfig().Image
 }

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -326,8 +326,3 @@ func (c Container) VerifyConfiguration() error {
 
 	return nil
 }
-
-// Image returns the image tag of the container as reported by the runtime config
-func (c Container) Image() string {
-	return c.runtimeConfig().Image
-}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -326,3 +326,7 @@ func (c Container) VerifyConfiguration() error {
 
 	return nil
 }
+
+func (c Container) Image() string {
+	return c.runtimeConfig().Image
+}

--- a/pkg/container/mocks/FilterableContainer.go
+++ b/pkg/container/mocks/FilterableContainer.go
@@ -78,3 +78,16 @@ func (_m *FilterableContainer) Scope() (string, bool) {
 
 	return r0, r1
 }
+
+func (_m *FilterableContainer) Image() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}

--- a/pkg/container/mocks/FilterableContainer.go
+++ b/pkg/container/mocks/FilterableContainer.go
@@ -79,6 +79,7 @@ func (_m *FilterableContainer) Scope() (string, bool) {
 	return r0, r1
 }
 
+// Image provides a mock function with given fields:
 func (_m *FilterableContainer) Image() string {
 	ret := _m.Called()
 

--- a/pkg/container/mocks/FilterableContainer.go
+++ b/pkg/container/mocks/FilterableContainer.go
@@ -79,8 +79,8 @@ func (_m *FilterableContainer) Scope() (string, bool) {
 	return r0, r1
 }
 
-// Image provides a mock function with given fields:
-func (_m *FilterableContainer) Image() string {
+// ImageName provides a mock function with given fields:
+func (_m *FilterableContainer) ImageName() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -70,6 +70,7 @@ func FilterByScope(scope string, baseFilter t.Filter) t.Filter {
 	}
 }
 
+// FilterByImageTag returns all containers that have a specific image
 func FilterByImageTag(tags []string, baseFilter t.Filter) t.Filter {
 	if tags == nil {
 		return baseFilter

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -70,16 +70,16 @@ func FilterByScope(scope string, baseFilter t.Filter) t.Filter {
 	}
 }
 
-// FilterByImageTag returns all containers that have a specific image
-func FilterByImageTag(tags []string, baseFilter t.Filter) t.Filter {
-	if tags == nil {
+// FilterByImage returns all containers that have a specific image
+func FilterByImage(images []string, baseFilter t.Filter) t.Filter {
+	if images == nil {
 		return baseFilter
 	}
 
 	return func(c t.FilterableContainer) bool {
 		image := strings.Split(c.Image(), ":")[0]
-		for _, targetTag := range tags {
-			if image == targetTag {
+		for _, targetImage := range images {
+			if image == targetImage {
 				return baseFilter(c)
 			}
 		}

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -70,6 +70,23 @@ func FilterByScope(scope string, baseFilter t.Filter) t.Filter {
 	}
 }
 
+func FilterByImageTag(tags []string, baseFilter t.Filter) t.Filter {
+	if tags == nil {
+		return baseFilter
+	}
+
+	return func(c t.FilterableContainer) bool {
+		image := c.Image()
+		for _, targetTag := range tags {
+			if image == targetTag {
+				return baseFilter(c)
+			}
+		}
+
+		return false
+	}
+}
+
 // BuildFilter creates the needed filter of containers
 func BuildFilter(names []string, enableLabel bool, scope string) (t.Filter, string) {
 	sb := strings.Builder{}

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -77,7 +77,7 @@ func FilterByImageTag(tags []string, baseFilter t.Filter) t.Filter {
 	}
 
 	return func(c t.FilterableContainer) bool {
-		image := c.Image()
+		image := strings.Split(c.Image(), ":")[0]
 		for _, targetTag := range tags {
 			if image == targetTag {
 				return baseFilter(c)

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -77,7 +77,7 @@ func FilterByImage(images []string, baseFilter t.Filter) t.Filter {
 	}
 
 	return func(c t.FilterableContainer) bool {
-		image := strings.Split(c.Image(), ":")[0]
+		image := strings.Split(c.ImageName(), ":")[0]
 		for _, targetImage := range images {
 			if image == targetImage {
 				return baseFilter(c)

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -111,31 +111,36 @@ func TestFilterByDisabledLabel(t *testing.T) {
 }
 
 func TestFilterByImage(t *testing.T) {
+	filterEmpty := FilterByImage(nil, NoFilter)
 	filterSingle := FilterByImage([]string{"registry"}, NoFilter)
 	filterMultiple := FilterByImage([]string{"registry", "bla"}, NoFilter)
 	assert.NotNil(t, filterSingle)
 	assert.NotNil(t, filterMultiple)
 
 	container := new(mocks.FilterableContainer)
-	container.On("Image").Return("registry:2")
+	container.On("ImageName").Return("registry:2")
+	assert.True(t, filterEmpty(container))
 	assert.True(t, filterSingle(container))
 	assert.True(t, filterMultiple(container))
 	container.AssertExpectations(t)
 
 	container = new(mocks.FilterableContainer)
-	container.On("Image").Return("registry:latest")
+	container.On("ImageName").Return("registry:latest")
+	assert.True(t, filterEmpty(container))
 	assert.True(t, filterSingle(container))
 	assert.True(t, filterMultiple(container))
 	container.AssertExpectations(t)
 
 	container = new(mocks.FilterableContainer)
-	container.On("Image").Return("abcdef1234")
+	container.On("ImageName").Return("abcdef1234")
+	assert.True(t, filterEmpty(container))
 	assert.False(t, filterSingle(container))
 	assert.False(t, filterMultiple(container))
 	container.AssertExpectations(t)
 
 	container = new(mocks.FilterableContainer)
-	container.On("Image").Return("bla:latest")
+	container.On("ImageName").Return("bla:latest")
+	assert.True(t, filterEmpty(container))
 	assert.False(t, filterSingle(container))
 	assert.True(t, filterMultiple(container))
 	container.AssertExpectations(t)

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -110,6 +110,41 @@ func TestFilterByDisabledLabel(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestFilterByImage(t *testing.T) {
+	filterSingle := FilterByImage([]string{"registry"}, NoFilter)
+	filterMultiple := FilterByImage([]string{"registry", "bla"}, NoFilter)
+	assert.NotNil(t, filterSingle)
+	assert.NotNil(t, filterMultiple)
+
+	filterNil := FilterByImage(nil, NoFilter)
+	assert.Same(t, filterNil, NoFilter)
+
+	container := new(mocks.FilterableContainer)
+	container.On("Image").Return("registry:2")
+	assert.True(t, filterSingle(container))
+	assert.True(t, filterMultiple(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Image").Return("registry:latest")
+	assert.True(t, filterSingle(container))
+	assert.True(t, filterMultiple(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Image").Return("abcdef1234")
+	assert.False(t, filterSingle(container))
+	assert.False(t, filterMultiple(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Image").Return("bla:latest")
+	assert.False(t, filterSingle(container))
+	assert.True(t, filterMultiple(container))
+	container.AssertExpectations(t)
+
+}
+
 func TestBuildFilter(t *testing.T) {
 	var names []string
 	names = append(names, "test")

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -116,9 +116,6 @@ func TestFilterByImage(t *testing.T) {
 	assert.NotNil(t, filterSingle)
 	assert.NotNil(t, filterMultiple)
 
-	filterNil := FilterByImage(nil, NoFilter)
-	assert.Same(t, filterNil, NoFilter)
-
 	container := new(mocks.FilterableContainer)
 	container.On("Image").Return("registry:2")
 	assert.True(t, filterSingle(container))

--- a/pkg/types/filterable_container.go
+++ b/pkg/types/filterable_container.go
@@ -7,4 +7,5 @@ type FilterableContainer interface {
 	IsWatchtower() bool
 	Enabled() (bool, bool)
 	Scope() (string, bool)
+	Image() string
 }

--- a/pkg/types/filterable_container.go
+++ b/pkg/types/filterable_container.go
@@ -7,5 +7,5 @@ type FilterableContainer interface {
 	IsWatchtower() bool
 	Enabled() (bool, bool)
 	Scope() (string, bool)
-	Image() string
+	ImageName() string
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

Implements the second request from #1285: Added an optional query parameter that allows you to only update containers of the specified image. This works even if the image was built locally (ie the container no longer has the image label in `docker ps`).

Also includes an indentation fix that Goland went on strike over.

I will implement the first request later today, and probably add the ability to specify more than one image as well. This draft PR is so there can be a code review of what's already been done.

Don't hold back on roasting my Go skills. :P