### PR TITLE
Support secrets for notification_url

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -181,7 +181,8 @@ If you want to disable TLS verification for the Gotify instance, you can use eit
 
 To send notifications via shoutrrr, the following command-line options, or their corresponding environment variables, can be set:
 
--   `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used.
+-   `--notification-url` (env. `WATCHTOWER_NOTIFICATION_URL`): The shoutrrr service URL to be used.  This option can also reference a file, in which case the contents of the file are used.
+
 
 Go to [containrrr.dev/shoutrrr/v0.5/services/overview](https://containrrr.dev/shoutrrr/v0.5/services/overview) to
 learn more about the different service URLs you can use. You can define multiple services by space separating the

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"bufio"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -453,10 +454,29 @@ func GetSecretsFromFiles(rootCmd *cobra.Command) {
 
 // getSecretFromFile will check if the flag contains a reference to a file; if it does, replaces the value of the flag with the contents of the file.
 func getSecretFromFile(flags *pflag.FlagSet, secret string) {
-	value, err := flags.GetString(secret)
-	if err != nil {
-		log.Error(err)
+	flag := flags.Lookup(secret)
+	if sliceValue, ok := flag.Value.(pflag.SliceValue); ok {
+		oldValues := sliceValue.GetSlice()
+		values := make([]string, 0, len(oldValues))
+		for _, value := range oldValues {
+			if value != "" && isFile(value) {
+				file, err := os.Open(value)
+				if err != nil {
+					log.Fatal(err)
+				}
+				scanner := bufio.NewScanner(file)
+				for scanner.Scan() {
+					values = append(values, scanner.Text())
+				}
+			} else {
+				values = append(values, value)
+			}
+		}
+		sliceValue.Replace(values)
+		return
 	}
+
+	value := flag.Value.String()
 	if value != "" && isFile(value) {
 		file, err := ioutil.ReadFile(value)
 		if err != nil {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -444,6 +444,7 @@ func GetSecretsFromFiles(rootCmd *cobra.Command) {
 		"notification-slack-hook-url",
 		"notification-msteams-hook",
 		"notification-gotify-token",
+		"notification-url",
 	}
 	for _, secret := range secrets {
 		getSecretFromFile(flags, secret)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -466,7 +466,11 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) {
 				}
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
-					values = append(values, scanner.Text())
+					line := scanner.Text()
+					if line == "" {
+						continue
+					}
+					values = append(values, line)
 				}
 			} else {
 				values = append(values, value)


### PR DESCRIPTION
Since the NOTIFICATION_URL contains app and user defined tokens, this PR adds support for the parameter to be loaded from a secret file.  Relevant documentation updated to note that a file path is supported.