### PR TITLE
fix(notifications): include icon in slack legacy url

### DIFF
--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -149,6 +149,8 @@ var _ = Describe("notifications", func() {
 			color := notifications.ColorInt
 			data := notifications.GetTemplateData(command)
 			title := url.QueryEscape(data.Title)
+			username := "containrrrbot"
+			iconURL := "https://containrrr.dev/watchtower-sq180.png"
 			expected := fmt.Sprintf("discord://%s@%s?color=0x%x&colordebug=0x0&colorerror=0x0&colorinfo=0x0&colorwarn=0x0&title=%s&username=watchtower", token, channel, color, title)
 			buildArgs := func(url string) []string {
 				return []string{
@@ -166,6 +168,31 @@ var _ = Describe("notifications", func() {
 			It("should return a discord url when using a hook url with the domain discordapp.com", func() {
 				hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s/slack", "discordapp.com", channel, token)
 				testURL(buildArgs(hookURL), expected, time.Duration(0))
+			})
+			It("should return a discord url when using a hook url with no trailing path arguments", func() {
+				hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s", "discord.com", channel, token)
+				testURL(buildArgs(hookURL), expected, time.Duration(0))
+			})
+			When("icon URL and username are specified", func() {
+				It("should return the expected URL", func() {
+					hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s", "discord.com", channel, token)
+					expectedOutput := fmt.Sprintf("discord://%s@%s?avatar=%s&color=0x%x&colordebug=0x0&colorerror=0x0&colorinfo=0x0&colorwarn=0x0&title=%s&username=%s", token, channel, url.QueryEscape(iconURL), color, title, username)
+					expectedDelay := time.Duration(7) * time.Second
+					args := []string{
+						"--notifications",
+						"slack",
+						"--notification-slack-hook-url",
+						hookURL,
+						"--notification-slack-identifier",
+						username,
+						"--notification-slack-icon-url",
+						iconURL,
+						"--notifications-delay",
+						fmt.Sprint(expectedDelay.Seconds()),
+					}
+
+					testURL(args, expectedOutput, expectedDelay)
+				})
 			})
 		})
 		When("converting a slack service config into a shoutrrr url", func() {

--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -169,13 +169,9 @@ var _ = Describe("notifications", func() {
 				hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s/slack", "discordapp.com", channel, token)
 				testURL(buildArgs(hookURL), expected, time.Duration(0))
 			})
-			It("should return a discord url when using a hook url with no trailing path arguments", func() {
-				hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s", "discord.com", channel, token)
-				testURL(buildArgs(hookURL), expected, time.Duration(0))
-			})
 			When("icon URL and username are specified", func() {
 				It("should return the expected URL", func() {
-					hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s", "discord.com", channel, token)
+					hookURL := fmt.Sprintf("https://%s/api/webhooks/%s/%s/slack", "discord.com", channel, token)
 					expectedOutput := fmt.Sprintf("discord://%s@%s?avatar=%s&color=0x%x&colordebug=0x0&colorerror=0x0&colorinfo=0x0&colorwarn=0x0&title=%s&username=%s", token, channel, url.QueryEscape(iconURL), color, title, username)
 					expectedDelay := time.Duration(7) * time.Second
 					args := []string{

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -49,8 +49,8 @@ func (s *slackTypeNotifier) GetURL(c *cobra.Command, title string) (string, erro
 	if parts[0] == "discord.com" || parts[0] == "discordapp.com" {
 		log.Debug("Detected a discord slack wrapper URL, using shoutrrr discord service")
 		conf := &shoutrrrDisco.Config{
-			WebhookID:  parts[3],
-			Token:      parts[4],
+			WebhookID:  parts[len(parts)-3],
+			Token:      parts[len(parts)-2],
 			Color:      ColorInt,
 			Title:      title,
 			SplitLines: true,

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -49,13 +49,18 @@ func (s *slackTypeNotifier) GetURL(c *cobra.Command, title string) (string, erro
 	if parts[0] == "discord.com" || parts[0] == "discordapp.com" {
 		log.Debug("Detected a discord slack wrapper URL, using shoutrrr discord service")
 		conf := &shoutrrrDisco.Config{
-			WebhookID:  parts[len(parts)-3],
-			Token:      parts[len(parts)-2],
+			WebhookID:  parts[3],
+			Token:      parts[4],
 			Color:      ColorInt,
 			Title:      title,
 			SplitLines: true,
 			Username:   s.Username,
 		}
+
+		if s.IconURL != "" {
+			conf.Avatar = s.IconURL
+		}
+
 		return conf.GetURL().String(), nil
 	}
 


### PR DESCRIPTION
#### Modified parsing of discord URLs:
 * The previous implementation assumed that the discord URL had a trailing path argument in the URL path
   * Ex: `https://discordapp.com/api/webhooks/WEBHOOK_ID/TOKEN/slack`
* However discord generates webhook URLs without the trailing path argument
  * Ex: `https://discordapp.com/api/webhooks/WEBHOOK_ID/TOKEN`
* Seeing as the `/slack` argument is never parsed by watchtower or sent to shoutrrr it should not be a requirement
* This PR addresses this issue by supporting URLs of both types:
  * `https://discordapp.com/api/webhooks/WEBHOOK_ID/TOKEN/slack` and `https://discordapp.com/api/webhooks/WEBHOOK_ID/TOKEN`

#### Added support for the `--notification-slack-icon-url` argument when using a discord webhook:
 * Previously this argument did nothing when using a discord webhook URL
 * Now it is parsed as the Avatar in the shoutrrr discord config

#### Added two tests for my additions
 * One to test the parsing of the `WEBHOOK_ID` and `TOKEN` when there is no trailing path argument in the discord webhook URL
 * One to test the parsing of the `--notification-slack-icon-url` argument with a discord webhook URL
   * This also tests the parsing of the `--notification-slack-identifier` argument with a discord webhook URL (not previously tested)


<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
