### PR TITLE
fix(templates): fix typo in grafana dashboard.json

### DIFF
--- a/grafana/dashboards/dashboard.json
+++ b/grafana/dashboards/dashboard.json
@@ -102,7 +102,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Faled"
+                "value": "Failed"
               }
             ]
           },


### PR DESCRIPTION
Fixes typo mentioned in issue #1304.
Value for "displayName" is fixed to become "Failed" instead of "Faled".

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
