### PR TITLE
feat: add porcelain output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,7 +109,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	scope, _ = f.GetString("scope")
 
 	if scope != "" {
-		log.Debug(`Using scope %q`, scope)
+		log.Debugf(`Using scope %q`, scope)
 	}
 
 	// configure environment vars for client

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,6 @@ var (
 	lifecycleHooks bool
 	rollingRestart bool
 	scope          string
-	// Set on build using ldflags
 )
 
 var rootCmd = NewRootCommand()
@@ -75,6 +74,7 @@ func Execute() {
 // PreRun is a lifecycle hook that runs before the command is executed.
 func PreRun(cmd *cobra.Command, _ []string) {
 	f := cmd.PersistentFlags()
+	flags.ProcessFlagAliases(f)
 
 	if enabled, _ := f.GetBool("no-color"); enabled {
 		log.SetFormatter(&log.TextFormatter{
@@ -94,18 +94,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		log.SetLevel(log.TraceLevel)
 	}
 
-	pollingSet := f.Changed("interval")
-	schedule, _ := f.GetString("schedule")
-	cronLen := len(schedule)
-
-	if pollingSet && cronLen > 0 {
-		log.Fatal("Only schedule or interval can be defined, not both.")
-	} else if cronLen > 0 {
-		scheduleSpec, _ = f.GetString("schedule")
-	} else {
-		interval, _ := f.GetInt("interval")
-		scheduleSpec = "@every " + strconv.Itoa(interval) + "s"
-	}
+	scheduleSpec, _ = f.GetString("schedule")
 
 	flags.GetSecretsFromFiles(cmd)
 	cleanup, noRestart, monitorOnly, timeout = flags.ReadFlags(cmd)
@@ -119,7 +108,9 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	rollingRestart, _ = f.GetBool("rolling-restart")
 	scope, _ = f.GetString("scope")
 
-	log.Debug(scope)
+	if scope != "" {
+		log.Debug(`Using scope %q`, scope)
+	}
 
 	// configure environment vars for client
 	err := flags.EnvConfig(cmd)

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -510,12 +510,12 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 		setFlagIfDefault(flags, `notification-template`, `porcelain.v1.summary-no-log`)
 	}
 
-	// update schedule flag to match interval if it's set
-	if flags.Changed(`interval`) {
-		schedule, _ := flags.GetString(`schedule`)
-		if len(schedule) > 0 {
-			log.Fatal(`Only schedule or interval can be defined, not both.`)
-		}
+	if flags.Changed(`interval`) && flags.Changed(`schedule`) {
+		log.Fatal(`Only schedule or interval can be defined, not both.`)
+	}
+
+	// update schedule flag to match interval if it's set, or to the default if none of them are
+	if flags.Changed(`interval`) || !flags.Changed(`schedule`) {
 		interval, _ := flags.GetInt(`interval`)
 		flags.Set(`schedule`, fmt.Sprintf(`@every %ds`, interval))
 	}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -551,6 +551,3 @@ func setFlagIfDefault(flags *pflag.FlagSet, name string, value string) {
 		log.Errorf(`Failed to set flag: %v`, err)
 	}
 }
- err)
-	}
-}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -118,7 +118,10 @@ func TestProcessFlagAliases(t *testing.T) {
 	RegisterSystemFlags(cmd)
 	RegisterNotificationFlags(cmd)
 
-	require.NoError(t, cmd.ParseFlags([]string{`--porcelain`, `--interval`, `10`}))
+	require.NoError(t, cmd.ParseFlags([]string{
+	    `--porcelain`, `v1`, 
+	    `--interval`, `10`,
+	}))
 	flags := cmd.Flags()
 	ProcessFlagAliases(flags)
 
@@ -147,6 +150,22 @@ func TestProcessFlagAliasesSchedAndInterval(t *testing.T) {
 	RegisterNotificationFlags(cmd)
 
 	require.NoError(t, cmd.ParseFlags([]string{`--schedule`, `@now`, `--interval`, `10`}))
+	flags := cmd.Flags()
+
+	assert.PanicsWithValue(t, `FATAL`, func() {
+		ProcessFlagAliases(flags)
+	})
+}
+
+func TestProcessFlagAliasesInvalidPorcelaineVersion(t *testing.T) {
+	logrus.StandardLogger().ExitFunc = func(_ int) { panic(`FATAL`) }
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+	RegisterNotificationFlags(cmd)
+
+	require.NoError(t, cmd.ParseFlags([]string{`--porcelain`, `cowboy`}))
 	flags := cmd.Flags()
 
 	assert.PanicsWithValue(t, `FATAL`, func() {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,4 +103,53 @@ func TestHTTPAPIPeriodicPollsFlag(t *testing.T) {
 func TestIsFile(t *testing.T) {
 	assert.False(t, isFile("https://google.com"), "an URL should never be considered a file")
 	assert.True(t, isFile(os.Args[0]), "the currently running binary path should always be considered a file")
+}
+
+func TestReadFlags(t *testing.T) {
+	logrus.StandardLogger().ExitFunc = func(_ int) { t.FailNow() }
+
+}
+
+func TestProcessFlagAliases(t *testing.T) {
+	logrus.StandardLogger().ExitFunc = func(_ int) { t.FailNow() }
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+	RegisterNotificationFlags(cmd)
+
+	require.NoError(t, cmd.ParseFlags([]string{`--porcelain`, `--interval`, `10`}))
+	flags := cmd.Flags()
+	ProcessFlagAliases(flags)
+
+	urls, _ := flags.GetStringArray(`notification-url`)
+	assert.Contains(t, urls, `logger://`)
+
+	logStdout, _ := flags.GetBool(`notification-log-stdout`)
+	assert.True(t, logStdout)
+
+	report, _ := flags.GetBool(`notification-report`)
+	assert.True(t, report)
+
+	template, _ := flags.GetString(`notification-template`)
+	assert.Equal(t, `porcelain.v1.summary-no-log`, template)
+
+	sched, _ := flags.GetString(`schedule`)
+	assert.Equal(t, `@every 10s`, sched)
+}
+
+func TestProcessFlagAliasesSchedAndInterval(t *testing.T) {
+	logrus.StandardLogger().ExitFunc = func(_ int) { panic(`FATAL`) }
+	cmd := new(cobra.Command)
+	SetDefaults()
+	RegisterDockerFlags(cmd)
+	RegisterSystemFlags(cmd)
+	RegisterNotificationFlags(cmd)
+
+	require.NoError(t, cmd.ParseFlags([]string{`--schedule`, `@now`, `--interval`, `10`}))
+	flags := cmd.Flags()
+
+	assert.PanicsWithValue(t, `FATAL`, func() {
+		ProcessFlagAliases(flags)
+	})
 }

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -28,9 +28,12 @@ var commonTemplates = map[string]string{
 
 	`porcelain.v1.summary-no-log`: `
 {{- if .Report -}}
-{{len .Report.All}} containers matched filter{{println}}
-  {{- range .Report.All}}
-  	{{- println}}{{.Name}} ({{.ImageName}}): {{.State}} {{- with .Error}} Error: {{.}}{{end}}
+  {{- range .Report.All }}
+    {{- .Name}} ({{.ImageName}}): {{.State -}}
+    {{- with .Error}} Error: {{.}}{{end}}{{ println }}
+  {{- else -}}
+    no containers matched filter
   {{- end -}}
 {{- end -}}`,
 }
+

--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -1,0 +1,36 @@
+package notifications
+
+var commonTemplates = map[string]string{
+	`default-legacy`: "{{range .}}{{.Message}}{{println}}{{end}}",
+
+	`default`: `
+{{- if .Report -}}
+  {{- with .Report -}}
+    {{- if ( or .Updated .Failed ) -}}
+{{len .Scanned}} Scanned, {{len .Updated}} Updated, {{len .Failed}} Failed
+      {{- range .Updated}}
+- {{.Name}} ({{.ImageName}}): {{.CurrentImageID.ShortID}} updated to {{.LatestImageID.ShortID}}
+      {{- end -}}
+      {{- range .Fresh}}
+- {{.Name}} ({{.ImageName}}): {{.State}}
+	  {{- end -}}
+	  {{- range .Skipped}}
+- {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
+	  {{- end -}}
+	  {{- range .Failed}}
+- {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
+	  {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{range .Entries -}}{{.Message}}{{"\n"}}{{- end -}}
+{{- end -}}`,
+
+	`porcelain.v1.summary-no-log`: `
+{{- if .Report -}}
+{{len .Report.All}} containers matched filter{{println}}
+  {{- range .Report.All}}
+  	{{- println}}{{.Name}} ({{.ImageName}}): {{.State}} {{- with .Error}} Error: {{.}}{{end}}
+  {{- end -}}
+{{- end -}}`,
+}

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -15,7 +15,6 @@ const (
 )
 
 type emailTypeNotifier struct {
-	url                                string
 	From, To                           string
 	Server, User, Password, SubjectTag string
 	Port                               int

--- a/pkg/notifications/notifier.go
+++ b/pkg/notifications/notifier.go
@@ -21,20 +21,21 @@ func NewNotifier(c *cobra.Command) ty.Notifier {
 		log.Fatalf("Notifications invalid log level: %s", err.Error())
 	}
 
-	acceptedLogLevels := slackrus.LevelThreshold(logLevel)
+	levels := slackrus.LevelThreshold(logLevel)
 	// slackrus does not allow log level TRACE, even though it's an accepted log level for logrus
-	if len(acceptedLogLevels) == 0 {
+	if len(levels) == 0 {
 		log.Fatalf("Unsupported notification log level provided: %s", level)
 	}
 
 	reportTemplate, _ := f.GetBool("notification-report")
+	stdout, _ := f.GetBool("notification-log-stdout")
 	tplString, _ := f.GetString("notification-template")
 	urls, _ := f.GetStringArray("notification-url")
 
 	data := GetTemplateData(c)
 	urls, delay := AppendLegacyUrls(urls, c, data.Title)
 
-	return newShoutrrrNotifier(tplString, acceptedLogLevels, !reportTemplate, data, delay, urls...)
+	return newShoutrrrNotifier(tplString, levels, !reportTemplate, data, delay, stdout, urls...)
 }
 
 // AppendLegacyUrls creates shoutrrr equivalent URLs from legacy notification flags

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Shoutrrr", func() {
 				cmd := new(cobra.Command)
 				flags.RegisterNotificationFlags(cmd)
 
-				shoutrrr := createNotifier([]string{}, logrus.AllLevels, "", true, StaticData{})
+				shoutrrr := createNotifier([]string{}, logrus.AllLevels, "", true, StaticData{}, false)
 
 				entries := []*logrus.Entry{
 					{
@@ -236,7 +236,7 @@ Turns out everything is on fire
 	When("batching notifications", func() {
 		When("no messages are queued", func() {
 			It("should not send any notification", func() {
-				shoutrrr := newShoutrrrNotifier("", allButTrace, true, StaticData{}, time.Duration(0), "logger://")
+				shoutrrr := newShoutrrrNotifier("", allButTrace, true, StaticData{}, time.Duration(0), false, "logger://")
 				shoutrrr.StartNotification()
 				shoutrrr.SendNotification(nil)
 				Consistently(logBuffer).ShouldNot(gbytes.Say(`Shoutrrr:`))
@@ -244,7 +244,7 @@ Turns out everything is on fire
 		})
 		When("at least one message is queued", func() {
 			It("should send a notification", func() {
-				shoutrrr := newShoutrrrNotifier("", allButTrace, true, StaticData{}, time.Duration(0), "logger://")
+				shoutrrr := newShoutrrrNotifier("", allButTrace, true, StaticData{}, time.Duration(0), false, "logger://")
 				shoutrrr.StartNotification()
 				logrus.Info("This log message is sponsored by ContainrrrVPN")
 				shoutrrr.SendNotification(nil)
@@ -258,7 +258,7 @@ Turns out everything is on fire
 			shoutrrr := createNotifier([]string{"logger://"}, allButTrace, "", true, StaticData{
 				Host:  "test.host",
 				Title: "",
-			})
+			}, false)
 			_, found := shoutrrr.params.Title()
 			Expect(found).ToNot(BeTrue())
 		})
@@ -290,7 +290,7 @@ type blockingRouter struct {
 }
 
 func (b blockingRouter) Send(_ string, _ *types.Params) []error {
-	_ = <-b.unlock
+	<-b.unlock
 	b.sent <- true
 	return nil
 }

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -76,9 +76,8 @@ var _ = Describe("Shoutrrr", func() {
 	When("passing a common template name", func() {
 		It("should format using that template", func() {
 			expected := `
-1 containers matched filter
-
-updt1 (mock/updt1:latest): Updated`[1:]
+updt1 (mock/updt1:latest): Updated
+`[1:]
 			data := mockDataFromStates(s.UpdatedState)
 			Expect(getTemplatedResult(`porcelain.v1.summary-no-log`, false, data)).To(Equal(expected))
 		})

--- a/pkg/notifications/shoutrrr_test.go
+++ b/pkg/notifications/shoutrrr_test.go
@@ -73,6 +73,17 @@ var _ = Describe("Shoutrrr", func() {
 		})
 	})
 
+	When("passing a common template name", func() {
+		It("should format using that template", func() {
+			expected := `
+1 containers matched filter
+
+updt1 (mock/updt1:latest): Updated`[1:]
+			data := mockDataFromStates(s.UpdatedState)
+			Expect(getTemplatedResult(`porcelain.v1.summary-no-log`, false, data)).To(Equal(expected))
+		})
+	})
+
 	When("using legacy templates", func() {
 
 		When("no custom template is provided", func() {
@@ -168,7 +179,6 @@ var _ = Describe("Shoutrrr", func() {
 	})
 
 	When("using report templates", func() {
-
 		When("no custom template is provided", func() {
 			It("should format the messages using the default template", func() {
 				expected := `4 Scanned, 2 Updated, 1 Failed

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -43,7 +43,7 @@ func newSlackNotifier(c *cobra.Command, acceptedLogLevels []log.Level) t.Convert
 
 func (s *slackTypeNotifier) GetURL(c *cobra.Command, title string) (string, error) {
 	trimmedURL := strings.TrimRight(s.HookURL, "/")
-	trimmedURL = strings.TrimLeft(trimmedURL, "https://")
+	trimmedURL = strings.TrimPrefix(trimmedURL, "https://")
 	parts := strings.Split(trimmedURL, "/")
 
 	if parts[0] == "discord.com" || parts[0] == "discordapp.com" {

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -8,6 +8,7 @@ type Report interface {
 	Skipped() []ContainerReport
 	Stale() []ContainerReport
 	Fresh() []ContainerReport
+	All() []ContainerReport
 }
 
 // ContainerReport represents a container that was included in watchtower session

--- a/scripts/docker-util.sh
+++ b/scripts/docker-util.sh
@@ -123,3 +123,39 @@ function container-started() {
   fi
   docker container inspect "$Name" | jq -r .[].State.StartedAt
 }
+
+
+function container-exists() {
+  local Name=$1
+  if [ -z "$Name" ];  then
+    echo "NAME missing"
+    return 1
+  fi
+  
+  docker container inspect "$Name" 1> /dev/null 2> /dev/null
+}
+
+function registry-exists() {
+  container-exists "$CONTAINER_PREFIX-registry"
+}
+
+function create-container() {
+  local container_name=$1
+    if [ -z "$container_name" ];  then
+    echo "NAME missing"
+    return 1
+  fi
+  local image_name="${2:-$container_name}"
+
+  echo -en "Creating \e[94m$container_name\e[0m container... "
+  local result=$(docker run -d --name "$container_name" $(registry-host)/$image_name 2>&1)
+  local result_len=$(echo $result | wc -c)
+  if [ "$result_len" -eq 65 ]; then
+    echo -e "\e[92m$(echo $result | cut -c -12)\e[0m"
+    return 0
+  else
+    echo -e "\e[91mFailed!\n\e[97m$result\e[0m"
+    echo $result_len
+    return 1
+  fi
+}

--- a/scripts/docker-util.sh
+++ b/scripts/docker-util.sh
@@ -148,14 +148,39 @@ function create-container() {
   local image_name="${2:-$container_name}"
 
   echo -en "Creating \e[94m$container_name\e[0m container... "
-  local result, result_len
+  local result
   result=$(docker run -d --name "$container_name" "$(registry-host)/$image_name" 2>&1)
-  result_len=${#result}
-  if [ "$result_len" -eq 65 ]; then
+  if [ "${#result}" -eq 64 ]; then
     echo -e "\e[92m${result:0:12}\e[0m"
     return 0
   else
     echo -e "\e[91mFailed!\n\e[97m$result\e[0m"
     return 1
   fi
+}
+
+function remove-images() {
+  local image_name=$1
+  if [ -z "$image_name" ];  then
+    echo "NAME missing"
+    return 1
+  fi
+
+  local images
+  mapfile -t images < <(docker images -q "$image_name" | uniq)
+  if [ -n "${images[*]}" ]; then
+    docker image rm "${images[@]}"
+  else
+    echo "No images matched \"$image_name\""
+  fi
+}
+
+function remove-repo-images() {
+  local image_name=$1
+  if [ -z "$image_name" ];  then
+    echo "NAME missing"
+    return 1
+  fi
+
+  remove-images "$(registry-host)/images/$image_name"
 }

--- a/scripts/docker-util.sh
+++ b/scripts/docker-util.sh
@@ -148,14 +148,14 @@ function create-container() {
   local image_name="${2:-$container_name}"
 
   echo -en "Creating \e[94m$container_name\e[0m container... "
-  local result=$(docker run -d --name "$container_name" $(registry-host)/$image_name 2>&1)
-  local result_len=$(echo $result | wc -c)
+  local result, result_len
+  result=$(docker run -d --name "$container_name" "$(registry-host)/$image_name" 2>&1)
+  result_len=${#result}
   if [ "$result_len" -eq 65 ]; then
-    echo -e "\e[92m$(echo $result | cut -c -12)\e[0m"
+    echo -e "\e[92m${result:0:12}\e[0m"
     return 0
   else
     echo -e "\e[91mFailed!\n\e[97m$result\e[0m"
-    echo $result_len
     return 1
   fi
 }

--- a/scripts/du-cli.sh
+++ b/scripts/du-cli.sh
@@ -61,9 +61,9 @@ case $1 in
         fi
         image_name="images/$3"
         container_name=$3
-        $0 image rev $image_name || exit 1
-        $0 container create $container_name $image_name || exit 1
-        $0 image rev $image_name || exit 1
+        $0 image rev "$image_name" || exit 1
+        $0 container create "$container_name" "$image_name" || exit 1
+        $0 image rev "$image_name" || exit 1
         ;;
       *)
         echo "Unknown container action \"$2\""

--- a/scripts/du-cli.sh
+++ b/scripts/du-cli.sh
@@ -16,7 +16,7 @@ case $1 in
         registry-host
         ;;
       *)
-        echo "Unknown keyword \"$2\""
+        echo "Unknown registry action \"$2\""
         ;;
     esac
     ;;
@@ -29,7 +29,7 @@ case $1 in
         latest-image-rev "$3"
         ;;
       *)
-        echo "Unknown keyword \"$2\""
+        echo "Unknown image action \"$2\""
         ;;
     esac
     ;;
@@ -47,8 +47,26 @@ case $1 in
       started)
         container-started "$3"
         ;;
+      create)
+        create-container "${@:3:2}"
+        ;;
+      create-stale)
+        if [ -z "$3" ]; then
+          echo "NAME missing"
+          exit 1
+        fi
+        if ! registry-exists; then
+          echo "Registry container missing! Creating..."
+          start-registry || exit 1
+        fi
+        image_name="images/$3"
+        container_name=$3
+        $0 image rev $image_name || exit 1
+        $0 container create $container_name $image_name || exit 1
+        $0 image rev $image_name || exit 1
+        ;;
       *)
-        echo "Unknown keyword \"$2\""
+        echo "Unknown container action \"$2\""
         ;;
     esac
     ;;

--- a/scripts/du-cli.sh
+++ b/scripts/du-cli.sh
@@ -28,6 +28,9 @@ case $1 in
       latest)
         latest-image-rev "$3"
         ;;
+      rm)
+        remove-repo-images "$3"
+        ;;
       *)
         echo "Unknown image action \"$2\""
         ;;


### PR DESCRIPTION
This PR adds the `--porcelain` flag to help with using watchtower in scripts. When set, it uses a built-in template (`porcelain.v1.summary-no-log`) and writes notifications to `stdout`.
The output is meant to be stable and easily processed by common scripting tools like `awk` etc. 

Versioning of the templates is done by passing the version to `--porcelain` as an argument, with only `v1` being supported for now. That way we can add newer versions of templates without breaking scripts.

The output of the `v1` template looks like this:
```
container_name1 (container_image1:tag): Updated
container_name2 (container_image2:tag): Fresh Error: no credentials
```
(fresh here just means that it's the latest version _we know of_, but checking failed so it might not be)

or:
```
no containers matched filter
```

Fixes #1336 