### PR TITLE
feat: allow log level to be set to any level

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,11 +87,11 @@ func PreRun(cmd *cobra.Command, _ []string) {
 		})
 	}
 
-	if enabled, _ := f.GetBool("debug"); enabled {
-		log.SetLevel(log.DebugLevel)
-	}
-	if enabled, _ := f.GetBool("trace"); enabled {
-		log.SetLevel(log.TraceLevel)
+	rawLogLevel, _ := f.GetString(`log-level`)
+	if logLevel, err := log.ParseLevel(rawLogLevel); err != nil {
+		log.Fatalf("Invalid log level: %s", err.Error())
+	} else {
+		log.SetLevel(logLevel)
 	}
 
 	scheduleSpec, _ = f.GetString("schedule")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -371,6 +371,6 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 		"Scanned": metricResults.Scanned,
 		"Updated": metricResults.Updated,
 		"Failed":  metricResults.Failed,
-	}).Info("Session done")
+	}).Debug("Session done")
 	return metricResults
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -371,6 +371,6 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 		"Scanned": metricResults.Scanned,
 		"Updated": metricResults.Updated,
 		"Failed":  metricResults.Failed,
-	}).Debug("Session done")
+	}).Info("Session done")
 	return metricResults
 }

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -71,9 +71,9 @@ Environment Variable: WATCHTOWER_REMOVE_VOLUMES
 ## Debug
 Enable debug mode with verbose logging.
 
-!!! note "Notes" 
+!!! note "Notes"  
     Alias for `--log-level debug`. See [Maximum log level](#maximum-log-level).  
-    Does *not* take an argument when used as an argument. Using `--debug true` will **not** work.
+    Does _not_ take an argument when used as an argument. Using `--debug true` will **not** work.
 
 ```text
             Argument: --debug, -d
@@ -87,7 +87,7 @@ Enable trace mode with very verbose logging. Caution: exposes credentials!
 
 !!! note "Notes"  
     Alias for `--log-level trace`. See [Maximum log level](#maximum-log-level).  
-    Does *not* take an argument when used as an argument. Using `--trace true` will **not** work.
+    Does _not_ take an argument when used as an argument. Using `--trace true` will **not** work.
 
 ```text
             Argument: --trace

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -71,6 +71,10 @@ Environment Variable: WATCHTOWER_REMOVE_VOLUMES
 ## Debug
 Enable debug mode with verbose logging.
 
+!!! note "Notes" 
+    Alias for `--log-level debug`. See [Maximum log level](#maximum-log-level).  
+    Does *not* take an argument when used as an argument. Using `--debug true` will **not** work.
+
 ```text
             Argument: --debug, -d
 Environment Variable: WATCHTOWER_DEBUG
@@ -81,11 +85,26 @@ Environment Variable: WATCHTOWER_DEBUG
 ## Trace
 Enable trace mode with very verbose logging. Caution: exposes credentials!
 
+!!! note "Notes"  
+    Alias for `--log-level trace`. See [Maximum log level](#maximum-log-level).  
+    Does *not* take an argument when used as an argument. Using `--trace true` will **not** work.
+
 ```text
             Argument: --trace
 Environment Variable: WATCHTOWER_TRACE
                 Type: Boolean
              Default: false
+```
+
+## Maximum log level
+
+The maximum log level that will be written to STDERR (shown in `docker log` when used in a container).
+
+```text
+            Argument: --log-level
+Environment Variable: WATCHTOWER_LOG_LEVEL
+     Possible values: panic, fatal, error, warn, info, debug or trace
+             Default: info
 ```
 
 ## ANSI colors

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -182,6 +182,10 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		viper.GetString("WATCHTOWER_PORCELAIN"),
 		`Write session results to stdout using a stable versioned format. Supported values: "v1"`)
 
+	flags.String(
+		"log-level",
+		viper.GetString("WATCHTOWER_LOG_LEVEL"),
+		"The maximum log level that will be written to STDERR. Possible values: panic, fatal, error, warn, info, debug or trace")
 }
 
 // RegisterNotificationFlags that are used by watchtower to send notifications
@@ -374,6 +378,7 @@ func SetDefaults() {
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT", 25)
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_EMAIL_SUBJECTTAG", "")
 	viper.SetDefault("WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER", "watchtower")
+	viper.SetDefault("WATCHTOWER_LOG_LEVEL", "info")
 }
 
 // EnvConfig translates the command-line options into environment variables
@@ -561,6 +566,23 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 		interval, _ := flags.GetInt(`interval`)
 		flags.Set(`schedule`, fmt.Sprintf(`@every %ds`, interval))
 	}
+
+	if flagIsEnabled(flags, `debug`) {
+		flags.Set(`log-level`, `debug`)
+	}
+
+	if flagIsEnabled(flags, `trace`) {
+		flags.Set(`log-level`, `trace`)
+	}
+
+}
+
+func flagIsEnabled(flags *pflag.FlagSet, name string) bool {
+	value, err := flags.GetBool(name)
+	if err != nil {
+		log.Fatalf(`The flag %q is not defined`, name)
+	}
+	return value
 }
 
 func appendFlagValue(flags *pflag.FlagSet, name string, values ...string) error {


### PR DESCRIPTION
When using watch tower for a convenient way to reload freshly built images from the local Docker registry (with --no-pull and a poll interval of one second), the "Session done" log message spams the logs: `level=info msg="Session done" Failed=0 Scanned=3 Updated=0 notify=no`.

Since this is really debug-oriented messaging, seems appropriate.


