### PR TITLE
Added missing arguments to slack notification documentation

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -125,6 +125,8 @@ By default, watchtower will send messages under the name `watchtower`, you can c
 Other, optional, variables include:
 
 -   `--notification-slack-channel` (env. `WATCHTOWER_NOTIFICATION_SLACK_CHANNEL`): A string which overrides the webhook's default channel. Example: #my-custom-channel.
+-   `--notification-slack-icon-emoji` (env. `WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI`): An emoji which is used as the notifications icon.
+-   `--notification-slack-icon-url` (env. `WATCHTOWER_NOTIFICATION_SLACK_ICON_URL`): A url to a picture that will be used as the notification icon.
 
 Example:
 


### PR DESCRIPTION
Added the following two arguments to the notification documentation.

- notification-slack-icon-emoji
- notification-slack-icon-url

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
