### PR TITLE
chore(github): add text render and remove default value

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -59,7 +59,7 @@ body:
     attributes:
       label: Your logs
       description: Paste the logs from running watchtower with the `--debug` option.
-      render: shell
+      render: text
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -58,11 +58,8 @@ body:
   - type: textarea
     attributes:
       label: Your logs
-      description: Paste the Logs from running watchtower with the `--debug` option between the backticks.
-      value: |
-        ```
-
-        ```
+      description: Paste the logs from running watchtower with the `--debug` option.
+      render: shell
     validations:
       required: true
 


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

Added the `render: text` argument to the log section of the bug report template.

This automatically places the text into a code block without the user having to put it in-between a  set of backticks.

## Screenshots
### When creating the issue
![image](https://user-images.githubusercontent.com/3665694/193707907-f506738c-6da0-46a3-8550-8ef3e130dfc0.png)
### When viewing the created issue
![image](https://user-images.githubusercontent.com/3665694/193707959-beea2f58-98d9-48f6-aad1-b4403a007cd5.png)


