### PR TITLE
docs: add dark mode

### DIFF
--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -6,6 +6,10 @@
     --md-accent-fg-color--transparent: #00334310;
 }
 
+[data-md-color-scheme="slate"] {
+    --md-typeset-a-color: #7f9ece;
+}
+
 .md-header-nav__button.md-logo {
     padding: 0;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,16 @@ edit_uri: edit/main/docs/
 theme:
   name: 'material'
   palette:
-    scheme: containrrr
+    - media: "(prefers-color-scheme: light)"
+      scheme: containrrr
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   logo: images/logo-450px.png
   favicon: images/favicon.ico
 extra_css:
@@ -24,7 +33,7 @@ markdown_extensions:
         repo: watchtower
     - pymdownx.saneheaders
     - pymdownx.tabbed:
-        alternate_style: true 
+        alternate_style: true
 nav:
    - 'Home': 'index.md'
    - 'Introduction': 'introduction.md'


### PR DESCRIPTION
This PR adds dark mode to the mkdocs-based documentation site. Pretty straightforward  with the great mkdocs tooling. Default mode will reflect user's OS preference, with ability to toggle dark/light mode after that. Main adjustment only in mkdocs.yml, but I also adjusted one style in theme.css so the links in dark mode are a bit more legible.

![image](https://user-images.githubusercontent.com/556505/194129365-be62c212-4dcb-426f-b398-fa5a42b788c4.png)
