### PR TITLE
feat: add no-pull label for containers

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -276,7 +276,7 @@ func (client dockerClient) RenameContainer(c Container, newName string) error {
 func (client dockerClient) IsContainerStale(container Container) (stale bool, latestImage t.ImageID, err error) {
 	ctx := context.Background()
 
-	if !client.PullImages {
+	if !client.PullImages || container.IsNoPull() {
 		log.Debugf("Skipping image pull.")
 	} else if err := client.PullImage(ctx, container); err != nil {
 		return false, container.SafeImageID(), err

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -124,6 +124,22 @@ func (c Container) IsMonitorOnly() bool {
 	return parsedBool
 }
 
+// IsNoPull returns the value of the no-pull label. If the label is not set
+// then false is returned.
+func (c Container) IsNoPull() bool {
+	rawBool, ok := c.getLabelValue(noPullLabel)
+	if !ok {
+		return false
+	}
+
+	parsedBool, err := strconv.ParseBool(rawBool)
+	if err != nil {
+		return false
+	}
+
+	return parsedBool
+}
+
 // Scope returns the value of the scope UID label and if the label
 // was set.
 func (c Container) Scope() (string, bool) {

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -1,18 +1,19 @@
 package container
 
 const (
-	watchtowerLabel       = "com.centurylinklabs.watchtower"
-	signalLabel           = "com.centurylinklabs.watchtower.stop-signal"
-	enableLabel           = "com.centurylinklabs.watchtower.enable"
-	monitorOnlyLabel      = "com.centurylinklabs.watchtower.monitor-only"
-	dependsOnLabel        = "com.centurylinklabs.watchtower.depends-on"
-	zodiacLabel           = "com.centurylinklabs.zodiac.original-image"
-	scope                 = "com.centurylinklabs.watchtower.scope"
-	preCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.pre-check"
-	postCheckLabel        = "com.centurylinklabs.watchtower.lifecycle.post-check"
-	preUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.pre-update"
-	postUpdateLabel       = "com.centurylinklabs.watchtower.lifecycle.post-update"
-	preUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
+	watchtowerLabel        = "com.centurylinklabs.watchtower"
+	signalLabel            = "com.centurylinklabs.watchtower.stop-signal"
+	enableLabel            = "com.centurylinklabs.watchtower.enable"
+	monitorOnlyLabel       = "com.centurylinklabs.watchtower.monitor-only"
+	noPullLabel            = "com.centurylinklabs.watchtower.no-pull"
+	dependsOnLabel         = "com.centurylinklabs.watchtower.depends-on"
+	zodiacLabel            = "com.centurylinklabs.zodiac.original-image"
+	scope                  = "com.centurylinklabs.watchtower.scope"
+	preCheckLabel          = "com.centurylinklabs.watchtower.lifecycle.pre-check"
+	postCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.post-check"
+	preUpdateLabel         = "com.centurylinklabs.watchtower.lifecycle.pre-update"
+	postUpdateLabel        = "com.centurylinklabs.watchtower.lifecycle.post-update"
+	preUpdateTimeoutLabel  = "com.centurylinklabs.watchtower.lifecycle.pre-update-timeout"
 	postUpdateTimeoutLabel = "com.centurylinklabs.watchtower.lifecycle.post-update-timeout"
 )
 


### PR DESCRIPTION
Resolves #1256.

This pull request adds support for a "no-pull" label (`com.centurylinklabs.watchtower.no-pull`) to enable the global functionality on a per-container basis.