### PR TITLE
fix: explicitly accept non-commands as root args

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func NewRootCommand() *cobra.Command {
 	`,
 		Run:    Run,
 		PreRun: PreRun,
+		Args:   cobra.ArbitraryArgs,
 	}
 }
 


### PR DESCRIPTION
explicitly allow arbitrary arguments to root command. 

fixes #1457.