### PR TITLE
fix(docs): use correct modern css color syntax

### DIFF
--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -14,56 +14,56 @@
   --md-hue: 199;
 
   /* Primary and accent */
-  --md-primary-fg-color:             hsla(199deg  27%  35% 100%);
-  --md-primary-fg-color--link:       hsla(199deg  45%  65% 100%);
-  --md-primary-fg-color--light:      hsla(198deg  19%  73% 100%);
-  --md-primary-fg-color--dark:       hsla(194deg 100%  13% 100%);
-  --md-accent-fg-color:              hsla(194deg  45%  50% 100%);
-  --md-accent-fg-color--transparent: hsla(194deg  45%  50% 6.3%);
+  --md-primary-fg-color:             hsl(199deg  27%  35% / 100%);
+  --md-primary-fg-color--link:       hsl(199deg  45%  65% / 100%);
+  --md-primary-fg-color--light:      hsl(198deg  19%  73% / 100%);
+  --md-primary-fg-color--dark:       hsl(194deg 100%  13% / 100%);
+  --md-accent-fg-color:              hsl(194deg  45%  50% / 100%);
+  --md-accent-fg-color--transparent: hsl(194deg  45%  50% / 6.3%);
 
   /* Default */
-  --md-default-fg-color:             hsla(var(--md-hue)  75%  95% 100%);
-  --md-default-fg-color--light:      hsla(var(--md-hue)  75%  90%  62%);
-  --md-default-fg-color--lighter:    hsla(var(--md-hue)  75%  90%  32%);
-  --md-default-fg-color--lightest:   hsla(var(--md-hue)  75%  90%  12%);
-  --md-default-bg-color:             hsla(var(--md-hue)  15%  21% 100%);
-  --md-default-bg-color--light:      hsla(var(--md-hue)  15%  21%  54%);
-  --md-default-bg-color--lighter:    hsla(var(--md-hue)  15%  21%  26%);
-  --md-default-bg-color--lightest:   hsla(var(--md-hue)  15%  21%   7%);
+  --md-default-fg-color:             hsl(var(--md-hue)  75%  95%  / 100%);
+  --md-default-fg-color--light:      hsl(var(--md-hue)  75%  90%  /  62%);
+  --md-default-fg-color--lighter:    hsl(var(--md-hue)  75%  90%  /  32%);
+  --md-default-fg-color--lightest:   hsl(var(--md-hue)  75%  90%  /  12%);
+  --md-default-bg-color:             hsl(var(--md-hue)  15%  21%  / 100%);
+  --md-default-bg-color--light:      hsl(var(--md-hue)  15%  21%  /  54%);
+  --md-default-bg-color--lighter:    hsl(var(--md-hue)  15%  21%  /  26%);
+  --md-default-bg-color--lightest:   hsl(var(--md-hue)  15%  21%  /   7%);
 
   /* Code */
-  --md-code-fg-color:                hsla(var(--md-hue) 18% 86% 100%);
-  --md-code-bg-color:                hsla(var(--md-hue) 15% 15% 100%);
-  --md-code-hl-color:                hsla(218deg 100%  63%  15%);
-  --md-code-hl-number-color:         hsla(346deg  74%  63% 100%);
-  --md-code-hl-special-color:        hsla(320deg  83%  66% 100%);
-  --md-code-hl-function-color:       hsla(271deg  57%  65% 100%);
-  --md-code-hl-constant-color:       hsla(230deg  62%  70% 100%);
-  --md-code-hl-keyword-color:        hsla(199deg  33%  64% 100%);
-  --md-code-hl-string-color:         hsla( 50deg  34%  74% 100%);
+  --md-code-fg-color:                hsl(var(--md-hue) 18% 86%  / 100%);
+  --md-code-bg-color:                hsl(var(--md-hue) 15% 15%  / 100%);
+  --md-code-hl-color:                hsl(218deg 100%  63%  /  15%);
+  --md-code-hl-number-color:         hsl(346deg  74%  63%  / 100%);
+  --md-code-hl-special-color:        hsl(320deg  83%  66%  / 100%);
+  --md-code-hl-function-color:       hsl(271deg  57%  65%  / 100%);
+  --md-code-hl-constant-color:       hsl(230deg  62%  70%  / 100%);
+  --md-code-hl-keyword-color:        hsl(199deg  33%  64%  / 100%);
+  --md-code-hl-string-color:         hsl( 50deg  34%  74%  / 100%);
   --md-code-hl-name-color:           var(--md-code-fg-color);
   --md-code-hl-operator-color:       var(--md-default-fg-color--light);
   --md-code-hl-punctuation-color:    var(--md-default-fg-color--light);
   --md-code-hl-comment-color:        var(--md-default-fg-color--light);
   --md-code-hl-generic-color:        var(--md-default-fg-color--light);
-  --md-code-hl-variable-color:       hsla(241deg  22%  60% 100%);
+  --md-code-hl-variable-color:       hsl(241deg  22%  60%  / 100%);
 
   /* Typeset */
   --md-typeset-color:                var(--md-default-fg-color);
   --md-typeset-a-color:              var(--md-primary-fg-color--link);
-  --md-typeset-mark-color:           hsla(218deg 100%  63%  30%);
-  --md-typeset-kbd-color:            hsla(var(--md-hue)  15%  94%  12%);
-  --md-typeset-kbd-accent-color:     hsla(var(--md-hue)  15%  94%  20%);
-  --md-typeset-kbd-border-color:     hsla(var(--md-hue)  15%  14% 100%);
-  --md-typeset-table-color:          hsla(var(--md-hue)  75%  95%  12%);
+  --md-typeset-mark-color:           hsl(218deg 100%  63%  / 30%);
+  --md-typeset-kbd-color:            hsl(var(--md-hue)  15%  94%  /  12%);
+  --md-typeset-kbd-accent-color:     hsl(var(--md-hue)  15%  94%  /  20%);
+  --md-typeset-kbd-border-color:     hsl(var(--md-hue)  15%  14%  / 100%);
+  --md-typeset-table-color:          hsl(var(--md-hue)  75%  95%  /  12%);
 
   /* Admonition */
   --md-admonition-fg-color:          var(--md-default-fg-color);
   --md-admonition-bg-color:          var(--md-default-bg-color);
 
   /* Footer */
-  --md-footer-bg-color:              hsla(var(--md-hue)  15%  12%  87%);
-  --md-footer-bg-color--dark:        hsla(var(--md-hue)  15%  10% 100%);
+  --md-footer-bg-color:              hsl(var(--md-hue)  15%  12% /  87%);
+  --md-footer-bg-color--dark:        hsl(var(--md-hue)  15%  10% / 100%);
 
   /* Shadows */
   --md-shadow-z1:


### PR DESCRIPTION
Fixes dark theme introduced in #1427, which was only partly upgraded to the new CSS color syntax, leaving it in an unsupported limbo.