### PR TITLE
feat(clean): log removed/untagged images

### DIFF
--- a/internal/util/rand_sha256.go
+++ b/internal/util/rand_sha256.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+)
+
+// GenerateRandomSHA256 generates a random 64 character SHA 256 hash string
+func GenerateRandomSHA256() string {
+	return GenerateRandomPrefixedSHA256()[7:]
+}
+
+// GenerateRandomPrefixedSHA256 generates a random 64 character SHA 256 hash string, prefixed with `sha256:`
+func GenerateRandomPrefixedSHA256() string {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	sb := bytes.NewBufferString("sha256:")
+	sb.Grow(64)
+	for _, h := range hash {
+		_, _ = fmt.Fprintf(sb, "%02x", h)
+	}
+	return sb.String()
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,8 +1,10 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
+	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSliceEqual_True(t *testing.T) {
@@ -61,4 +63,16 @@ func TestStructMapSubtract(t *testing.T) {
 	assert.Equal(t, map[string]struct{}{"b": x}, result)
 	assert.Equal(t, map[string]struct{}{"a": x, "b": x, "c": x}, m1)
 	assert.Equal(t, map[string]struct{}{"a": x, "c": x}, m2)
+}
+
+// GenerateRandomSHA256 generates a random 64 character SHA 256 hash string
+func TestGenerateRandomSHA256(t *testing.T) {
+	res := GenerateRandomSHA256()
+	assert.Len(t, res, 64)
+	assert.NotContains(t, res, "sha256:")
+}
+
+func TestGenerateRandomPrefixedSHA256(t *testing.T) {
+	res := GenerateRandomPrefixedSHA256()
+	assert.Regexp(t, regexp.MustCompile("sha256:[0-9|a-f]{64}"), res)
 }


### PR DESCRIPTION
Add additional `debug` logging with the actual removed images (target image and any parent images) when running with `--cleanup` to help diagnosing left over images.