### PR TITLE
feat: ignore removal error due to non-existing containers

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -192,6 +192,10 @@ func (client dockerClient) StopContainer(c Container, timeout time.Duration) err
 		log.Debugf("Removing container %s", shortID)
 
 		if err := client.api.ContainerRemove(bg, idStr, types.ContainerRemoveOptions{Force: true, RemoveVolumes: client.RemoveVolumes}); err != nil {
+			if sdkClient.IsErrNotFound(err) {
+				log.Debugf("Container %s not found, skipping removal.", shortID)
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
This PR allows watchtower to ignore a failure to remove containers that doesn't exist. This can be useful when the start of the containers is managed by docker compose or an external system such as systemd.

Watchtower causes an issue for me in combination with the `--abort-on-container-exit` flag for dockers `compose up` subcommand.

Docker compose removed the container on its own after the container was stopped. This leads to an error when watchtower attempts to remove the container.

`Error: No such container: 425173...`

The error is thrown by this [ContainerRemove](https://github.com/containrrr/watchtower/blob/d744c3488667d6cc4bb8258bb4b351bfd80e1602/pkg/container/client.go#L194) call.

Fixes #1480 