### PR TITLE
Add podman support

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -226,6 +227,15 @@ func (client dockerClient) StartContainer(c Container) (t.ContainerID, error) {
 	}()
 
 	name := c.Name()
+
+	// detect podman
+	// podman makes /run/.containerenv, docker makes /run/.dockerenv
+	_, err := os.Stat("/run/.containerenv")
+	if err == nil {
+		// podman workaround
+		name = name[1:]
+		hostConfig.Ulimits = nil
+	}
 
 	log.Infof("Creating %s", name)
 	createdContainer, err := client.api.ContainerCreate(bg, config, hostConfig, simpleNetworkConfig, nil, name)


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
Closes #1060

When making container, it checks if running in podman (by checking if /run/.containerenv file exists, that only is made when running with podman). If yes, then it applies workarounds:

- Removes leading slash from container name (podman doesn't support that)
- Doesnt set ulimits (also breaks podman)