### PR TITLE
fix(docs): fix anchor links in the metrics part

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,7 +4,7 @@
 
 Metrics can be used to track how Watchtower behaves over time.
 
-To use this feature, you have to set an [API token](arguments.md#http-api-token) and [enable the metrics API](arguments.md#http-api-metrics),
+To use this feature, you have to set an [API token](arguments.md#http_api_token) and [enable the metrics API](arguments.md#http_api_metrics),
 as well as creating a port mapping for your container for port `8080`.
 
 The metrics API endpoint is `/v1/metrics`.


### PR DESCRIPTION
Fix the anchor links in the metrics part of the documentation. 