### PR TITLE
fix: update metrics from sessions started via API

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,10 @@ func Run(c *cobra.Command, names []string) {
 	httpAPI := api.New(apiToken)
 
 	if enableUpdateAPI {
-		updateHandler := update.New(func(images []string) { runUpdatesWithNotifications(filters.FilterByImage(images, filter)) }, updateLock)
+		updateHandler := update.New(func(images []string) {
+			metric := runUpdatesWithNotifications(filters.FilterByImage(images, filter))
+			metrics.RegisterScan(metric)
+		}, updateLock)
 		httpAPI.RegisterFunc(updateHandler.Path, updateHandler.Handle)
 		// If polling isn't enabled the scheduler is never started and
 		// we need to trigger the startup messages manually.


### PR DESCRIPTION
## Description

This PR fixes  #1530. Metrics are not captured and returned to the metrics handler if called via the HTTP API. This code is already implemented in the existing codebase when a schedule is triggered. https://github.com/containrrr/watchtower/blob/c16ac967c5f34c278feaac44e755ab2a88319457/cmd/root.go#L322-L323 

## Tests

Ran binary with the following arguments:  `--cleanup --schedule "0 0 4 * * *" --http-api-update --http-api-token "******" --http-api-periodic-polls --http-api-metrics`. And curl'd the update endpoint. The below logs were outputted after a successful run. 
```
INFO[0015] Updates triggered by HTTP API request.
INFO[0022] Session done                                  Failed=0 Scanned=18 Updated=0 notify=no
```
Finally curled the metrics endpoint and saw the correct metric was updated.
```
watchtower_containers_scanned 18
```