### PR TITLE
feat: add oci image index support

### DIFF
--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -103,6 +103,7 @@ func GetDigest(url string, token string) (string, error) {
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.list.v2+json")
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v1+json")
+	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
 	logrus.WithField("url", url).Debug("Doing a HEAD request to fetch a digest")
 


### PR DESCRIPTION
This PR simply appends `application/vnd.oci.image.index.v1+json` to the `Accepted` header when querying for image manifests. This format was added to `docker buildx` v0.10 and for images that use it, causes watchtower 1.5.1 to fail checking for changes using HEAD requests (since the repository returns a 404 when the `Accept`ed mime type is not present for the manifest).

When testing locally, watchtower was able to get the digests for all the found problematic images.

Fixes #1528.