### PR TITLE
fix: remove logging of credentials

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -91,7 +91,8 @@ func GetBearerHeader(challenge string, img string, registryAuth string) (string,
 
 	if registryAuth != "" {
 		logrus.Debug("Credentials found.")
-		logrus.Tracef("Credentials: %v", registryAuth)
+		// CREDENTIAL: Uncomment to log registry credentials
+		// logrus.Tracef("Credentials: %v", registryAuth)
 		r.Header.Add("Authorization", fmt.Sprintf("Basic %s", registryAuth))
 	} else {
 		logrus.Debug("No credentials found.")

--- a/pkg/registry/digest/digest.go
+++ b/pkg/registry/digest/digest.go
@@ -6,15 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/containrrr/watchtower/internal/meta"
 	"github.com/containrrr/watchtower/pkg/registry/auth"
 	"github.com/containrrr/watchtower/pkg/registry/manifest"
 	"github.com/containrrr/watchtower/pkg/types"
 	"github.com/sirupsen/logrus"
-	"net"
-	"net/http"
-	"strings"
-	"time"
 )
 
 // ContentDigestHeader is the key for the key-value pair containing the digest header
@@ -25,7 +26,7 @@ func CompareDigest(container types.Container, registryAuth string) (bool, error)
 	if !container.HasImageInfo() {
 		return false, errors.New("container image info missing")
 	}
-	
+
 	var digest string
 
 	registryAuth = TransformAuth(registryAuth)
@@ -93,11 +94,12 @@ func GetDigest(url string, token string) (string, error) {
 	req, _ := http.NewRequest("HEAD", url, nil)
 	req.Header.Set("User-Agent", meta.UserAgent)
 
-	if token != "" {
-		logrus.WithField("token", token).Trace("Setting request token")
-	} else {
+	if token == "" {
 		return "", errors.New("could not fetch token")
 	}
+
+	// CREDENTIAL: Uncomment to log the request token
+	// logrus.WithField("token", token).Trace("Setting request token")
 
 	req.Header.Add("Authorization", token)
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -19,7 +19,9 @@ func GetPullOptions(imageName string) (types.ImagePullOptions, error) {
 	if auth == "" {
 		return types.ImagePullOptions{}, nil
 	}
-	log.Tracef("Got auth value: %s", auth)
+
+	// CREDENTIAL: Uncomment to log docker config auth
+	// log.Tracef("Got auth value: %s", auth)
 
 	return types.ImagePullOptions{
 		RegistryAuth:  auth,

--- a/pkg/registry/trust.go
+++ b/pkg/registry/trust.go
@@ -38,7 +38,8 @@ func EncodedEnvAuth(ref string) (string, error) {
 			Password: password,
 		}
 		log.Debugf("Loaded auth credentials for user %s on registry %s", auth.Username, ref)
-		log.Tracef("Using auth password %s", auth.Password)
+		// CREDENTIAL: Uncomment to log REPO_PASS environment variable
+		// log.Tracef("Using auth password %s", auth.Password)
 		return EncodeAuth(auth)
 	}
 	return "", errors.New("registry auth environment variables (REPO_USER, REPO_PASS) not set")
@@ -71,7 +72,8 @@ func EncodedConfigAuth(ref string) (string, error) {
 		return "", nil
 	}
 	log.Debugf("Loaded auth credentials for user %s, on registry %s, from file %s", auth.Username, ref, configFile.Filename)
-	log.Tracef("Using auth password %s", auth.Password)
+	// CREDENTIAL: Uncomment to log docker config password
+	// log.Tracef("Using auth password %s", auth.Password)
 	return EncodeAuth(auth)
 }
 


### PR DESCRIPTION
This PR will remove most of the unsafe logging when running with `--trace`. The reason for this change is that it might be used as a vulnerability and there is no good scenario for when they would be useful (since we don't want users including the information in the issues/discussions anyway).

*If* the user/developer needs that information, the corresponding line can just be uncommented and built  locally:
```
❯ grep -r 'CREDENTIAL:' .
./pkg/registry/auth/auth.go:            // CREDENTIAL: Uncomment to log registry credentials
./pkg/registry/digest/digest.go:        // CREDENTIAL: Uncomment to log the request token
./pkg/registry/trust.go:                // CREDENTIAL: Uncomment to log REPO_PASS environment variable
./pkg/registry/trust.go:        // CREDENTIAL: Uncomment to log docker config password
./pkg/registry/registry.go:     // CREDENTIAL: Uncomment to log docker config auth
```

The two places where the logging still remains is the notification URL generated by updating legacy notifications to Shoutrrr URLs, and the docker image/container info logged when watchtower does not have enough information to update a container.