### PR TITLE
feat(notifications): add json template

### DIFF
--- a/pkg/notifications/common_templates.go
+++ b/pkg/notifications/common_templates.go
@@ -35,5 +35,6 @@ var commonTemplates = map[string]string{
     no containers matched filter
   {{- end -}}
 {{- end -}}`,
-}
 
+	`json.v1`: `{{ . | ToJSON }}`,
+}

--- a/pkg/notifications/json.go
+++ b/pkg/notifications/json.go
@@ -6,13 +6,13 @@ import (
 	t "github.com/containrrr/watchtower/pkg/types"
 )
 
-type JSONMap = map[string]interface{}
+type jsonMap = map[string]interface{}
 
 // MarshalJSON implements json.Marshaler
 func (d Data) MarshalJSON() ([]byte, error) {
-	var entries = make([]JSONMap, len(d.Entries))
+	var entries = make([]jsonMap, len(d.Entries))
 	for i, entry := range d.Entries {
-		entries[i] = JSONMap{
+		entries[i] = jsonMap{
 			`level`:   entry.Level,
 			`message`: entry.Message,
 			`data`:    entry.Data,
@@ -20,9 +20,9 @@ func (d Data) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	var report JSONMap
+	var report jsonMap
 	if d.Report != nil {
-		report = JSONMap{
+		report = jsonMap{
 			`scanned`: marshalReports(d.Report.Scanned()),
 			`updated`: marshalReports(d.Report.Updated()),
 			`failed`:  marshalReports(d.Report.Failed()),
@@ -32,7 +32,7 @@ func (d Data) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return json.Marshal(JSONMap{
+	return json.Marshal(jsonMap{
 		`report`:  report,
 		`title`:   d.Title,
 		`host`:    d.Host,
@@ -40,10 +40,10 @@ func (d Data) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func marshalReports(reports []t.ContainerReport) []JSONMap {
-	jsonReports := make([]JSONMap, len(reports))
+func marshalReports(reports []t.ContainerReport) []jsonMap {
+	jsonReports := make([]jsonMap, len(reports))
 	for i, report := range reports {
-		jsonReports[i] = JSONMap{
+		jsonReports[i] = jsonMap{
 			`id`:             report.ID().ShortID(),
 			`name`:           report.Name(),
 			`currentImageId`: report.CurrentImageID().ShortID(),
@@ -61,10 +61,11 @@ func marshalReports(reports []t.ContainerReport) []JSONMap {
 var _ json.Marshaler = &Data{}
 
 func toJSON(v interface{}) string {
-	if bytes, err := json.MarshalIndent(v, "", "  "); err != nil {
+	var bytes []byte
+	var err error
+	if bytes, err = json.MarshalIndent(v, "", "  "); err != nil {
 		LocalLog.Errorf("failed to marshal JSON in notification template: %v", err)
 		return ""
-	} else {
-		return string(bytes)
 	}
+	return string(bytes)
 }

--- a/pkg/notifications/json.go
+++ b/pkg/notifications/json.go
@@ -44,10 +44,10 @@ func marshalReports(reports []t.ContainerReport) []JSONMap {
 	jsonReports := make([]JSONMap, len(reports))
 	for i, report := range reports {
 		jsonReports[i] = JSONMap{
-			`id`:             report.ID(),
+			`id`:             report.ID().ShortID(),
 			`name`:           report.Name(),
-			`currentImageId`: report.CurrentImageID(),
-			`latestImageId`:  report.LatestImageID(),
+			`currentImageId`: report.CurrentImageID().ShortID(),
+			`latestImageId`:  report.LatestImageID().ShortID(),
 			`imageName`:      report.ImageName(),
 			`state`:          report.State(),
 		}

--- a/pkg/notifications/json.go
+++ b/pkg/notifications/json.go
@@ -1,0 +1,70 @@
+package notifications
+
+import (
+	"encoding/json"
+
+	t "github.com/containrrr/watchtower/pkg/types"
+)
+
+type JSONMap = map[string]interface{}
+
+// MarshalJSON implements json.Marshaler
+func (d Data) MarshalJSON() ([]byte, error) {
+	var entries = make([]JSONMap, len(d.Entries))
+	for i, entry := range d.Entries {
+		entries[i] = JSONMap{
+			`level`:   entry.Level,
+			`message`: entry.Message,
+			`data`:    entry.Data,
+			`time`:    entry.Time,
+		}
+	}
+
+	var report JSONMap
+	if d.Report != nil {
+		report = JSONMap{
+			`scanned`: marshalReports(d.Report.Scanned()),
+			`updated`: marshalReports(d.Report.Updated()),
+			`failed`:  marshalReports(d.Report.Failed()),
+			`skipped`: marshalReports(d.Report.Skipped()),
+			`stale`:   marshalReports(d.Report.Stale()),
+			`fresh`:   marshalReports(d.Report.Fresh()),
+		}
+	}
+
+	return json.Marshal(JSONMap{
+		`report`:  report,
+		`title`:   d.Title,
+		`host`:    d.Host,
+		`entries`: entries,
+	})
+}
+
+func marshalReports(reports []t.ContainerReport) []JSONMap {
+	jsonReports := make([]JSONMap, len(reports))
+	for i, report := range reports {
+		jsonReports[i] = JSONMap{
+			`id`:             report.ID(),
+			`name`:           report.Name(),
+			`currentImageId`: report.CurrentImageID(),
+			`latestImageId`:  report.LatestImageID(),
+			`imageName`:      report.ImageName(),
+			`state`:          report.State(),
+		}
+		if errorMessage := report.Error(); errorMessage != "" {
+			jsonReports[i][`error`] = errorMessage
+		}
+	}
+	return jsonReports
+}
+
+var _ json.Marshaler = &Data{}
+
+func toJSON(v interface{}) string {
+	if bytes, err := json.MarshalIndent(v, "", "  "); err != nil {
+		LocalLog.Errorf("failed to marshal JSON in notification template: %v", err)
+		return ""
+	} else {
+		return string(bytes)
+	}
+}

--- a/pkg/notifications/json_test.go
+++ b/pkg/notifications/json_test.go
@@ -1,0 +1,118 @@
+package notifications
+
+import (
+	s "github.com/containrrr/watchtower/pkg/session"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JSON template", func() {
+	When("using report templates", func() {
+		When("JSON template is used", func() {
+			It("should format the messages to the expected format", func() {
+				expected := `{
+	"entries": [
+			{
+				"data": null,
+				"level": "info",
+				"message": "foo Bar",
+				"time": "0001-01-01T00:00:00Z"
+			}
+		],
+		"host": "Mock",
+		"report": {
+		"failed": [
+			{
+				"currentImageId": "01d210000000",
+				"error": "accidentally the whole container",
+				"id": "c79210000000",
+				"imageName": "mock/fail1:latest",
+				"latestImageId": "d0a210000000",
+				"name": "fail1",
+				"state": "Failed"
+			}
+		],
+		"fresh": [
+			{
+				"currentImageId": "01d310000000",
+				"id": "c79310000000",
+				"imageName": "mock/frsh1:latest",
+				"latestImageId": "01d310000000",
+				"name": "frsh1",
+				"state": "Fresh"
+			}
+		],
+		"scanned": [
+			{
+				"currentImageId": "01d110000000",
+				"id": "c79110000000",
+				"imageName": "mock/updt1:latest",
+				"latestImageId": "d0a110000000",
+				"name": "updt1",
+				"state": "Updated"
+			},
+			{
+				"currentImageId": "01d120000000",
+				"id": "c79120000000",
+				"imageName": "mock/updt2:latest",
+				"latestImageId": "d0a120000000",
+				"name": "updt2",
+				"state": "Updated"
+			},
+			{
+				"currentImageId": "01d210000000",
+				"error": "accidentally the whole container",
+				"id": "c79210000000",
+				"imageName": "mock/fail1:latest",
+				"latestImageId": "d0a210000000",
+				"name": "fail1",
+				"state": "Failed"
+			},
+			{
+				"currentImageId": "01d310000000",
+				"id": "c79310000000",
+				"imageName": "mock/frsh1:latest",
+				"latestImageId": "01d310000000",
+				"name": "frsh1",
+				"state": "Fresh"
+			}
+		],
+		"skipped": [
+			{
+				"currentImageId": "01d410000000",
+				"error": "unpossible",
+				"id": "c79410000000",
+				"imageName": "mock/skip1:latest",
+				"latestImageId": "01d410000000",
+				"name": "skip1",
+				"state": "Skipped"
+			}
+		],
+		"stale": [],
+		"updated": [
+			{
+				"currentImageId": "01d110000000",
+				"id": "c79110000000",
+				"imageName": "mock/updt1:latest",
+				"latestImageId": "d0a110000000",
+				"name": "updt1",
+				"state": "Updated"
+			},
+			{
+				"currentImageId": "01d120000000",
+				"id": "c79120000000",
+				"imageName": "mock/updt2:latest",
+				"latestImageId": "d0a120000000",
+				"name": "updt2",
+				"state": "Updated"
+			}
+		]
+		},
+		"title": "Watchtower updates on Mock"
+}`
+				data := mockDataFromStates(s.UpdatedState, s.FreshState, s.FailedState, s.SkippedState, s.UpdatedState)
+				Expect(getTemplatedResult(`json.v1`, false, data)).To(MatchJSON(expected))
+			})
+		})
+	})
+})

--- a/pkg/notifications/model.go
+++ b/pkg/notifications/model.go
@@ -1,0 +1,19 @@
+package notifications
+
+import (
+	t "github.com/containrrr/watchtower/pkg/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// StaticData is the part of the notification template data model set upon initialization
+type StaticData struct {
+	Title string
+	Host  string
+}
+
+// Data is the notification template data model
+type Data struct {
+	StaticData
+	Entries []*log.Entry
+	Report  t.Report
+}

--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -210,6 +210,7 @@ func getShoutrrrTemplate(tplString string, legacy bool) (tpl *template.Template,
 	funcs := template.FuncMap{
 		"ToUpper": strings.ToUpper,
 		"ToLower": strings.ToLower,
+		"ToJSON":  toJSON,
 		"Title":   cases.Title(language.AmericanEnglish).String,
 	}
 	tplBase := template.New("").Funcs(funcs)
@@ -239,17 +240,4 @@ func getShoutrrrTemplate(tplString string, legacy bool) (tpl *template.Template,
 	}
 
 	return
-}
-
-// StaticData is the part of the notification template data model set upon initialization
-type StaticData struct {
-	Title string
-	Host  string
-}
-
-// Data is the notification template data model
-type Data struct {
-	StaticData
-	Entries []*log.Entry
-	Report  t.Report
 }


### PR DESCRIPTION
This adds the `ToJSON` template function to notifications, allows the template data to JSON serialized and adds a built in default JSON template (simply `{{ . | ToJSON }}`).

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
Fixes #1478 and allows for better compatibility with #1523.