### PR TITLE
fix: always add missing slashes to link names

### DIFF
--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/containrrr/watchtower/internal/util"
 	"github.com/containrrr/watchtower/pkg/container"
@@ -260,10 +259,6 @@ func UpdateImplicitRestart(containers []container.Container) {
 // container marked for restart
 func linkedContainerMarkedForRestart(links []string, containers []container.Container) string {
 	for _, linkName := range links {
-		// Since the container names need to start with '/', let's prepend it if it's missing
-		if !strings.HasPrefix(linkName, "/") {
-			linkName = "/" + linkName
-		}
 		for _, candidate := range containers {
 			if candidate.Name() == linkName && candidate.ToRestart() {
 				return linkName

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -160,7 +160,14 @@ func (c Container) Links() []string {
 	dependsOnLabelValue := c.getLabelValueOrEmpty(dependsOnLabel)
 
 	if dependsOnLabelValue != "" {
-		links := strings.Split(dependsOnLabelValue, ",")
+		for _, link := range strings.Split(dependsOnLabelValue, ",") {
+			// Since the container names need to start with '/', let's prepend it if it's missing
+			if !strings.HasPrefix(link, "/") {
+				link = "/" + link
+			}
+			links = append(links, link)
+		}
+
 		return links
 	}
 

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -178,14 +178,21 @@ var _ = Describe("the container", func() {
 						"com.centurylinklabs.watchtower.depends-on": "postgres",
 					}))
 					links := c.Links()
-					Expect(links).To(SatisfyAll(ContainElement("postgres"), HaveLen(1)))
+					Expect(links).To(SatisfyAll(ContainElement("/postgres"), HaveLen(1)))
 				})
 				It("should fetch depending containers if there are many", func() {
 					c = MockContainer(WithLabels(map[string]string{
 						"com.centurylinklabs.watchtower.depends-on": "postgres,redis",
 					}))
 					links := c.Links()
-					Expect(links).To(SatisfyAll(ContainElement("postgres"), ContainElement("redis"), HaveLen(2)))
+					Expect(links).To(SatisfyAll(ContainElement("/postgres"), ContainElement("/redis"), HaveLen(2)))
+				})
+				It("should only add slashes to names when they are missing", func() {
+					c = MockContainer(WithLabels(map[string]string{
+						"com.centurylinklabs.watchtower.depends-on": "/postgres,redis",
+					}))
+					links := c.Links()
+					Expect(links).To(SatisfyAll(ContainElement("/postgres"), ContainElement("/redis")))
 				})
 				It("should fetch depending containers if label is blank", func() {
 					c = MockContainer(WithLabels(map[string]string{


### PR DESCRIPTION
This PR changes so that container links (which are most of the time actually sourced from `depends-on` labels) are always prefixed with `/`. Previously, this was only done when marking  dependant containers for restart, but since the names should ALWAYS start with a slash, this fix should be performed every time the container links are iterated.  
The only downside to this is that it's less performant (as it needs to copy the strings instead of just having the slices point to the same source string), but it should not be noticeable.

Since the links are used to match against container names, only fixing the slashes in one place caused some strange behaviour which should now be fixed:

- fixes #1266
- fixes #1579 


<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
