### PR TITLE
remove empty pair in auth response header www-authenticate

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -118,7 +118,8 @@ func GetAuthURL(challenge string, img string) (*url.URL, error) {
 	loweredChallenge := strings.ToLower(challenge)
 	raw := strings.TrimPrefix(loweredChallenge, "bearer")
 
-	pairs := strings.Split(raw, ",")
+	// split raw into pairs but skip empty strings
+	pairs := strings.FieldsFunc(raw, func(c rune) bool { return c == ',' })
 	values := make(map[string]string, len(pairs))
 
 	for _, pair := range pairs {


### PR DESCRIPTION
this pull request remove empty pair in auth response header www-authenticate, some cloud container registry may send more empty pair in there auth response, which will cause watchtower crash, this peice of code will filter empty pair, so watchtower can keep running.

fix #1624 
