### PR TITLE
fix(registry): ignore empty challenge fields

### DIFF
--- a/pkg/registry/auth/auth.go
+++ b/pkg/registry/auth/auth.go
@@ -123,10 +123,9 @@ func GetAuthURL(challenge string, img string) (*url.URL, error) {
 
 	for _, pair := range pairs {
 		trimmed := strings.Trim(pair, " ")
-		kv := strings.Split(trimmed, "=")
-		key := kv[0]
-		val := strings.Trim(kv[1], "\"")
-		values[key] = val
+		if key, val, ok := strings.Cut(trimmed, "="); ok {
+			values[key] = strings.Trim(val, `"`)
+		}
 	}
 	logrus.WithFields(logrus.Fields{
 		"realm":   values["realm"],

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -86,6 +86,12 @@ var _ = Describe("the auth module", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).NotTo(BeNil())
 		})
+		It("should not crash when a field without a value is recieved", func() {
+			input := `bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull",valuelesskey`
+			res, err := auth.GetAuthURL(input, "containrrr/watchtower")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).NotTo(BeNil())
+		})
 	})
 	When("getting a challenge url", func() {
 		It("should create a valid challenge url object based on the image ref supplied", func() {

--- a/pkg/registry/auth/auth_test.go
+++ b/pkg/registry/auth/auth_test.go
@@ -2,12 +2,13 @@ package auth_test
 
 import (
 	"fmt"
-	"github.com/containrrr/watchtower/internal/actions/mocks"
-	"github.com/containrrr/watchtower/pkg/registry/auth"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/containrrr/watchtower/internal/actions/mocks"
+	"github.com/containrrr/watchtower/pkg/registry/auth"
 
 	wtTypes "github.com/containrrr/watchtower/pkg/types"
 	. "github.com/onsi/ginkgo"
@@ -78,6 +79,12 @@ var _ = Describe("the auth module", func() {
 			res, err := auth.GetAuthURL(input, "containrrr/watchtower")
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(BeNil())
+		})
+		It("should not crash when an empty field is recieved", func() {
+			input := `bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull",`
+			res, err := auth.GetAuthURL(input, "containrrr/watchtower")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).NotTo(BeNil())
 		})
 	})
 	When("getting a challenge url", func() {


### PR DESCRIPTION
The `GetAuthURL` method splits challenge response header fields by `=` and then stores the key and value in a map. If an empty field (or a key without a value) is encountered, this causes a "index out of range" panic.

This PR replaces the unchecked `strings.Split` with `strings.Cut`, and skips any fields that does not contain a value.

Fixes #1624.