### PR TITLE
docs: add "HTTP API Mode" link to nav menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
    - 'Stop signals': 'stop-signals.md'
    - 'Lifecycle hooks': 'lifecycle-hooks.md'
    - 'Running multiple instances': 'running-multiple-instances.md'
+   - 'HTTP API Mode': 'http-api-mode.md'
    - 'Metrics': 'metrics.md'
 plugins:
     - search


### PR DESCRIPTION
It would be nice to have it there and not look for a link in the "Arguments" section every time