### PR TITLE
fix: only remove container id network aliases

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -230,9 +230,18 @@ func (client dockerClient) GetNetworkConfig(c t.Container) *network.NetworkingCo
 	}
 
 	for _, ep := range config.EndpointsConfig {
-		// This keeps accumulating across upgrades with no apparent added value
-		// so throwing the information away to prevent overflows.
-		ep.Aliases = nil
+		aliases := make([]string, 0, len(ep.Aliases))
+		cidAlias := c.ID().ShortID()
+
+		// Remove the old container ID alias from the network aliases, as it would accumulate across updates otherwise
+		for _, alias := range ep.Aliases {
+			if alias == cidAlias {
+				continue
+			}
+			aliases = append(aliases, alias)
+		}
+
+		ep.Aliases = aliases
 	}
 	return config
 }

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -317,19 +317,20 @@ var _ = Describe("the client", func() {
 	})
 	Describe(`GetNetworkConfig`, func() {
 		When(`providing a container with network aliases`, func() {
-			It(`should purge the aliases`, func() {
-				aliases := []string{"One", "Two"}
+			It(`should omit the container ID alias`, func() {
 				client := dockerClient{
 					api:           docker,
 					ClientOptions: ClientOptions{PullImages: false, IncludeRestarting: false},
 				}
 				container := MockContainer(WithImageName("docker.io/prefix/imagename:latest"))
+
+				aliases := []string{"One", "Two", container.ID().ShortID(), "Four"}
 				endpoints := map[string]*network.EndpointSettings{
 					`test`: {Aliases: aliases},
 				}
 				container.containerInfo.NetworkSettings = &types.NetworkSettings{Networks: endpoints}
 				Expect(container.ContainerInfo().NetworkSettings.Networks[`test`].Aliases).To(Equal(aliases))
-				Expect(client.GetNetworkConfig(container).EndpointsConfig[`test`].Aliases).To(BeEmpty())
+				Expect(client.GetNetworkConfig(container).EndpointsConfig[`test`].Aliases).To(Equal([]string{"One", "Two", "Four"}))
 			})
 		})
 	})


### PR DESCRIPTION
This is a follow up to #1699 that makes the alias removal a bit less aggressive.
The network aliases that accumulate are old container IDs, so this change will only remove those from the network configuration. This will allow any aliases added by docker compose (or by other means) to still be left in the new container.

The downside is that it will no longer clear any already accumulated old container ID aliases, but this should at least prevent it from escalating.

Fixes #1723
Ref #521