### PR TITLE
fix(notifications): correctly set the delay from options

### DIFF
--- a/pkg/notifications/shoutrrr.go
+++ b/pkg/notifications/shoutrrr.go
@@ -110,6 +110,7 @@ func createNotifier(urls []string, level log.Level, tplString string, legacy boo
 		legacyTemplate: legacy,
 		data:           data,
 		params:         params,
+		delay:          delay,
 	}
 }
 


### PR DESCRIPTION
`--notifications-delay` was ignored by soutrrr notifications because it wasn't set on creation.

I tested with `dockerfiles/Dockerfile.self-contained`

--- 

Caused by #1377 
Probably solves #1485 (needs confirmation)