### PR TITLE
test(flags): ensure temp files are cleaned up

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -503,7 +502,7 @@ func getSecretFromFile(flags *pflag.FlagSet, secret string) {
 
 	value := flag.Value.String()
 	if value != "" && isFile(value) {
-		file, err := ioutil.ReadFile(value)
+		file, err := os.ReadFile(value)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -564,15 +563,15 @@ func ProcessFlagAliases(flags *pflag.FlagSet) {
 	// update schedule flag to match interval if it's set, or to the default if none of them are
 	if intervalChanged || !scheduleChanged {
 		interval, _ := flags.GetInt(`interval`)
-		flags.Set(`schedule`, fmt.Sprintf(`@every %ds`, interval))
+		_ = flags.Set(`schedule`, fmt.Sprintf(`@every %ds`, interval))
 	}
 
 	if flagIsEnabled(flags, `debug`) {
-		flags.Set(`log-level`, `debug`)
+		_ = flags.Set(`log-level`, `debug`)
 	}
 
 	if flagIsEnabled(flags, `trace`) {
-		flags.Set(`log-level`, `trace`)
+		_ = flags.Set(`log-level`, `trace`)
 	}
 
 }
@@ -593,7 +592,7 @@ func appendFlagValue(flags *pflag.FlagSet, name string, values ...string) error 
 
 	if flagValues, ok := flag.Value.(pflag.SliceValue); ok {
 		for _, value := range values {
-			flagValues.Append(value)
+			_ = flagValues.Append(value)
 		}
 	} else {
 		return fmt.Errorf(`the value for flag %q is not a slice value`, name)

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1,13 +1,12 @@
 package flags
 
 import (
-	"os"
-	"testing"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
 )
 
 func TestEnvConfig_Defaults(t *testing.T) {
@@ -60,9 +59,9 @@ func TestGetSecretsFromFilesWithFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the secret to the temporary file.
-	secret := []byte(value)
-	_, err = file.Write(secret)
+	_, err = file.Write([]byte(value))
 	require.NoError(t, err)
+	require.NoError(t, file.Close())
 
 	t.Setenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD", file.Name())
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,8 +12,8 @@ import (
 
 func TestEnvConfig_Defaults(t *testing.T) {
 	// Unset testing environments own variables, since those are not what is under test
-	os.Unsetenv("DOCKER_TLS_VERIFY")
-	os.Unsetenv("DOCKER_HOST")
+	_ = os.Unsetenv("DOCKER_TLS_VERIFY")
+	_ = os.Unsetenv("DOCKER_HOST")
 
 	cmd := new(cobra.Command)
 	SetDefaults()
@@ -48,10 +47,7 @@ func TestEnvConfig_Custom(t *testing.T) {
 
 func TestGetSecretsFromFilesWithString(t *testing.T) {
 	value := "supersecretstring"
-
-	err := os.Setenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD", value)
-	require.NoError(t, err)
-	defer os.Unsetenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD")
+	t.Setenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD", value)
 
 	testGetSecretsFromFiles(t, "notification-email-server-password", value)
 }
@@ -60,18 +56,15 @@ func TestGetSecretsFromFilesWithFile(t *testing.T) {
 	value := "megasecretstring"
 
 	// Create the temporary file which will contain a secret.
-	file, err := ioutil.TempFile(os.TempDir(), "watchtower-")
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
 	require.NoError(t, err)
-	defer os.Remove(file.Name()) // Make sure to remove the temporary file later.
 
 	// Write the secret to the temporary file.
 	secret := []byte(value)
 	_, err = file.Write(secret)
 	require.NoError(t, err)
 
-	err = os.Setenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD", file.Name())
-	require.NoError(t, err)
-	defer os.Unsetenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD")
+	t.Setenv("WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PASSWORD", file.Name())
 
 	testGetSecretsFromFiles(t, "notification-email-server-password", value)
 }
@@ -80,16 +73,15 @@ func TestGetSliceSecretsFromFiles(t *testing.T) {
 	values := []string{"entry2", "", "entry3"}
 
 	// Create the temporary file which will contain a secret.
-	file, err := ioutil.TempFile(os.TempDir(), "watchtower-")
+	file, err := os.CreateTemp(t.TempDir(), "watchtower-")
 	require.NoError(t, err)
-	defer os.Remove(file.Name()) // Make sure to remove the temporary file later.
 
 	// Write the secret to the temporary file.
 	for _, value := range values {
 		_, err = file.WriteString("\n" + value)
 		require.NoError(t, err)
 	}
-	file.Close()
+	require.NoError(t, file.Close())
 
 	testGetSecretsFromFiles(t, "notification-url", `[entry1,entry2,entry3]`,
 		`--notification-url`, "entry1",
@@ -166,9 +158,7 @@ func TestProcessFlagAliases(t *testing.T) {
 
 func TestProcessFlagAliasesLogLevelFromEnvironment(t *testing.T) {
 	cmd := new(cobra.Command)
-	err := os.Setenv("WATCHTOWER_DEBUG", `true`)
-	require.NoError(t, err)
-	defer os.Unsetenv("WATCHTOWER_DEBUG")
+	t.Setenv("WATCHTOWER_DEBUG", `true`)
 
 	SetDefaults()
 	RegisterDockerFlags(cmd)
@@ -202,9 +192,7 @@ func TestProcessFlagAliasesSchedAndInterval(t *testing.T) {
 func TestProcessFlagAliasesScheduleFromEnvironment(t *testing.T) {
 	cmd := new(cobra.Command)
 
-	err := os.Setenv("WATCHTOWER_SCHEDULE", `@hourly`)
-	require.NoError(t, err)
-	defer os.Unsetenv("WATCHTOWER_SCHEDULE")
+	t.Setenv("WATCHTOWER_SCHEDULE", `@hourly`)
 
 	SetDefaults()
 	RegisterDockerFlags(cmd)


### PR DESCRIPTION
Before, the tests actually left temporary files on windows due to floating file handles. This fix will fix warnings in `flags` and `flags_test` and ensures that the temporary files are removed (or it will fail the tests).
