### PR TITLE
feat: enabled loading http-api-token from file

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -27,6 +27,33 @@ In the example above, watchtower will execute an upgrade attempt on the containe
 
 When no arguments are specified, watchtower will monitor all running containers.
 
+## Secrets/Files
+
+Some arguments can also reference a file, in which case the contents of the file are used as the value.
+This can be used to avoid putting secrets in the configuration file or command line.
+
+The following arguments are currently supported (including their corresponding `WATCHTOWER_` environment variables):
+ - `notification-url`
+ - `notification-email-server-password`
+ - `notification-slack-hook-url`
+ - `notification-msteams-hook`
+ - `notification-gotify-token`
+ - `http-api-token`
+
+### Example docker-compose usage
+```yaml
+secrets:
+  access_token:
+    file: access_token
+
+services:
+  watchtower:
+    secrets:
+      - access_token
+    environment:
+      - WATCHTOWER_HTTP_API_TOKEN=/run/secrets/access_token
+```
+
 ## Help
 Shows documentation about the supported flags.
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -270,6 +270,7 @@ Environment Variable: WATCHTOWER_HTTP_API_UPDATE
 
 ## HTTP API Token
 Sets an authentication token to HTTP API requests.
+Can also reference a file, in which case the contents of the file are used.
 
 ```text
             Argument: --http-api-token

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -466,6 +466,7 @@ func GetSecretsFromFiles(rootCmd *cobra.Command) {
 		"notification-msteams-hook",
 		"notification-gotify-token",
 		"notification-url",
+		"http-api-token",
 	}
 	for _, secret := range secrets {
 		if err := getSecretFromFile(flags, secret); err != nil {

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -90,6 +90,7 @@ func TestGetSliceSecretsFromFiles(t *testing.T) {
 func testGetSecretsFromFiles(t *testing.T, flagName string, expected string, args ...string) {
 	cmd := new(cobra.Command)
 	SetDefaults()
+	RegisterSystemFlags(cmd)
 	RegisterNotificationFlags(cmd)
 	require.NoError(t, cmd.ParseFlags(args))
 	GetSecretsFromFiles(cmd)


### PR DESCRIPTION
This adds `http-api-token` to the list of arguments that watchtower tries to load from a file if they exist (fixes #1711).

Additionally, this adds some more (easier to find) docs about the usage (fixes #1390).