### PR TITLE
add support for opencontainers meta labels

### DIFF
--- a/internal/actions/mocks/client.go
+++ b/internal/actions/mocks/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	dockerTypes "github.com/docker/docker/api/types"
+
 	t "github.com/containrrr/watchtower/pkg/types"
 )
 
@@ -64,6 +66,11 @@ func (client MockClient) RenameContainer(_ t.Container, _ string) error {
 func (client MockClient) RemoveImageByID(_ t.ImageID) error {
 	client.TestData.TriedToRemoveImageCount++
 	return nil
+}
+
+// GetImage is a mock method
+func (client MockClient) GetImage(_ t.ImageID) (dockerTypes.ImageInspect, error) {
+	return dockerTypes.ImageInspect{}, nil
 }
 
 // GetContainer is a mock method

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -34,6 +34,7 @@ type Client interface {
 	ExecuteCommand(containerID t.ContainerID, command string, timeout int) (SkipUpdate bool, err error)
 	RemoveImageByID(t.ImageID) error
 	WarnOnHeadPullFailed(container t.Container) bool
+	GetImage(imageID t.ImageID) (types.ImageInspect, error)
 }
 
 // NewClient returns a new Client instance which can be used to interact with
@@ -395,6 +396,14 @@ func (client dockerClient) PullImage(ctx context.Context, container t.Container)
 		return err
 	}
 	return nil
+}
+
+func (client dockerClient) GetImage(id t.ImageID) (types.ImageInspect, error) {
+	imageInfo, _, err := client.api.ImageInspectWithRaw(context.Background(), string(id))
+	if err != nil {
+		return types.ImageInspect{}, err
+	}
+	return imageInfo, nil
 }
 
 func (client dockerClient) RemoveImageByID(id t.ImageID) error {

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -25,7 +25,9 @@ type ContainerStatus struct {
 	containerName string
 	imageName     string
 	error
-	state State
+	state      State
+	beforeMeta imageMeta
+	afterMeta  imageMeta
 }
 
 // ID returns the container ID
@@ -79,4 +81,14 @@ func (u *ContainerStatus) State() string {
 	default:
 		return "Unknown"
 	}
+}
+
+// Before returns the metadata for the image considered latest before the session
+func (u *ContainerStatus) Before() wt.ImageMeta {
+	return u.beforeMeta
+}
+
+// After returns the metadata for the image considered latest after the session
+func (u *ContainerStatus) After() wt.ImageMeta {
+	return u.afterMeta
 }

--- a/pkg/session/image_meta.go
+++ b/pkg/session/image_meta.go
@@ -1,0 +1,55 @@
+package session
+
+import "strings"
+
+type imageMeta map[string]string
+
+func imageMetaFromLabels(labels map[string]string) imageMeta {
+	im := make(imageMeta)
+	for key, value := range labels {
+		if suffix, found := strings.CutPrefix(key, "org.opencontainers.image."); found {
+			im[suffix] = value
+		}
+	}
+	return im
+}
+
+func (im imageMeta) Authors() string {
+	return im["authors"]
+}
+
+func (im imageMeta) Created() string {
+	return im["created"]
+}
+
+func (im imageMeta) Description() string {
+	return im["description"]
+}
+
+func (im imageMeta) Documentation() string {
+	return im["documentation"]
+}
+
+func (im imageMeta) Licenses() string {
+	return im["licenses"]
+}
+
+func (im imageMeta) Revision() string {
+	return im["revision"]
+}
+
+func (im imageMeta) Source() string {
+	return im["source"]
+}
+
+func (im imageMeta) Title() string {
+	return im["title"]
+}
+
+func (im imageMeta) Url() string {
+	return im["url"]
+}
+
+func (im imageMeta) Version() string {
+	return im["version"]
+}

--- a/pkg/session/image_meta.go
+++ b/pkg/session/image_meta.go
@@ -4,11 +4,14 @@ import "strings"
 
 type imageMeta map[string]string
 
+const openContainersPrefix = "org.opencontainers.image."
+
 func imageMetaFromLabels(labels map[string]string) imageMeta {
 	im := make(imageMeta)
 	for key, value := range labels {
-		if suffix, found := strings.CutPrefix(key, "org.opencontainers.image."); found {
-			im[suffix] = value
+		if strings.HasPrefix(key, openContainersPrefix) {
+			strippedKey := key[len(openContainersPrefix):]
+			im[strippedKey] = value
 		}
 	}
 	return im

--- a/pkg/types/image_meta.go
+++ b/pkg/types/image_meta.go
@@ -1,0 +1,14 @@
+package types
+
+type ImageMeta interface {
+	Authors() string
+	Created() string
+	Description() string
+	Documentation() string
+	Licenses() string
+	Revision() string
+	Source() string
+	Title() string
+	Url() string
+	Version() string
+}

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -20,4 +20,6 @@ type ContainerReport interface {
 	ImageName() string
 	Error() string
 	State() string
+	Before() ImageMeta
+	After() ImageMeta
 }


### PR DESCRIPTION
This PR will add some support for the [OpenContainers metadata labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md), which can provide additional information about updated images in notifications.

Example template usage:
```go
  {{- if .Report -}}
    {{- with .Report -}}
        {{- range .Updated}}
  - {{.Before.Title}} ({{.ImageName}}) was updated from version {{.Before.Version}} to {{.After.Version}} (released {{.After.Created}})
        {{- end -}}
  {{- else -}}
    {{range .Entries -}}{{.Message}}{{"\n"}}{{- end -}}
  {{- end -}}
```