### PR TITLE
docs: clarify what volumes are removed when requested

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -85,8 +85,8 @@ Environment Variable: WATCHTOWER_CLEANUP
              Default: false
 ```
 
-## Remove attached volumes
-Removes attached volumes after updating. When this flag is specified, watchtower will remove all attached volumes from the container before restarting with a new image. Use this option to force new volumes to be populated as containers are updated.
+## Remove anonymous volumes
+Removes anonymous volumes after updating. When this flag is specified, watchtower will remove all anonymous volumes from the container before restarting with a new image. Named volumes will not be removed!
 
 ```text
             Argument: --remove-volumes


### PR DESCRIPTION
Update docs to reflect what the `--remove-volumes` option actually does.

I tracked the code back to https://github.com/moby/moby/blob/a01bcf9767c91c91bde4be5a32b151e256e74523/client/container_remove.go#L13 and then searched in the api docs: https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerDelete. There it is clearly stated: 
![image](https://github.com/containrrr/watchtower/assets/42591237/6edb51c1-4a61-4d81-84e3-bf2244e103a5)
