### PR TITLE
docs: bump go version in credential helper example

### DIFF
--- a/docs/private-registries.md
+++ b/docs/private-registries.md
@@ -124,7 +124,7 @@ in a volume that may be mounted onto your watchtower container.
 
 1.  Create the Dockerfile (contents below):
     ```Dockerfile
-    FROM golang:1.16
+    FROM golang:1.17
     
     ENV GO111MODULE off
     ENV CGO_ENABLED 0


### PR DESCRIPTION
Amazon credential helper updates mean using GO 1.16 will cause slice errors. e.g.

```
undefined: unsafe.Slice
```

[Using 1.17 as the source FROM fixes this](https://stackoverflow.com/questions/73735732/the-command-bin-sh-c-go-build-o-image-srv-returned-a-non-zero-code-2).

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
