### PR TITLE
ft: allow detect changes local images

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -311,6 +311,10 @@ func (client dockerClient) RenameContainer(c t.Container, newName string) error 
 func (client dockerClient) IsContainerStale(container t.Container) (stale bool, latestImage t.ImageID, err error) {
 	ctx := context.Background()
 
+	if isLocalImage, checkErr := container.LocalImage(); checkErr && isLocalImage {
+		return client.HasNewImage(ctx, container)
+	}
+
 	if !client.PullImages || container.IsNoPull() {
 		log.Debugf("Skipping image pull.")
 	} else if err := client.PullImage(ctx, container); err != nil {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -113,6 +113,22 @@ func (c Container) ImageName() string {
 	return imageName
 }
 
+// Local returns the value of the container local label and if the label
+// was set.
+func (c Container) LocalImage() (bool, bool) {
+	rawBool, ok := c.getLabelValue(enableLocal)
+	if !ok {
+		return false, false
+	}
+
+	parsedBool, err := strconv.ParseBool(rawBool)
+	if err != nil {
+		return false, false
+	}
+
+	return parsedBool, true
+}
+
 // Enabled returns the value of the container enabled label and if the label
 // was set.
 func (c Container) Enabled() (bool, bool) {

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -4,6 +4,7 @@ const (
 	watchtowerLabel        = "com.centurylinklabs.watchtower"
 	signalLabel            = "com.centurylinklabs.watchtower.stop-signal"
 	enableLabel            = "com.centurylinklabs.watchtower.enable"
+	enableLocal            = "com.centurylinklabs.watchtower.local-image"
 	monitorOnlyLabel       = "com.centurylinklabs.watchtower.monitor-only"
 	noPullLabel            = "com.centurylinklabs.watchtower.no-pull"
 	dependsOnLabel         = "com.centurylinklabs.watchtower.depends-on"

--- a/pkg/types/container.go
+++ b/pkg/types/container.go
@@ -75,4 +75,5 @@ type Container interface {
 	IsRestarting() bool
 	GetCreateConfig() *dc.Config
 	GetCreateHostConfig() *dc.HostConfig
+	LocalImage() (bool, bool)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->

fixes: https://github.com/containrrr/watchtower/issues/416

Desc: Allow watchtower detects changes local images, this is helpful if you run watchtower on your machine and you want to test your images on locally before release to production env.

How to use this feature:
- You need to add a label `com.centurylinklabs.watchtower.local-image=true` when run your container.
- The new image have the same name with the image used in your container.
