### PR TITLE
feat(filters): Add a flag/env to explicitly exclude containers by name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,18 +29,19 @@ import (
 )
 
 var (
-	client          container.Client
-	scheduleSpec    string
-	cleanup         bool
-	noRestart       bool
-	monitorOnly     bool
-	enableLabel     bool
-	notifier        t.Notifier
-	timeout         time.Duration
-	lifecycleHooks  bool
-	rollingRestart  bool
-	scope           string
-	labelPrecedence bool
+	client            container.Client
+	scheduleSpec      string
+	cleanup           bool
+	noRestart         bool
+	monitorOnly       bool
+	enableLabel       bool
+	disableContainers []string
+	notifier          t.Notifier
+	timeout           time.Duration
+	lifecycleHooks    bool
+	rollingRestart    bool
+	scope             string
+	labelPrecedence   bool
 )
 
 var rootCmd = NewRootCommand()
@@ -93,6 +94,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 	}
 
 	enableLabel, _ = f.GetBool("label-enable")
+	disableContainers, _ = f.GetStringSlice("disable-containers")
 	lifecycleHooks, _ = f.GetBool("enable-lifecycle-hooks")
 	rollingRestart, _ = f.GetBool("rolling-restart")
 	scope, _ = f.GetString("scope")
@@ -134,7 +136,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 
 // Run is the main execution flow of the command
 func Run(c *cobra.Command, names []string) {
-	filter, filterDesc := filters.BuildFilter(names, enableLabel, scope)
+	filter, filterDesc := filters.BuildFilter(names, disableContainers, enableLabel, scope)
 	runOnce, _ := c.PersistentFlags().GetBool("run-once")
 	enableUpdateAPI, _ := c.PersistentFlags().GetBool("http-api-update")
 	enableMetricsAPI, _ := c.PersistentFlags().GetBool("http-api-metrics")

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -230,6 +230,19 @@ __Do not__ Monitor and update containers that have `com.centurylinklabs.watchtow
 no `--label-enable` argument is passed. Note that only one or the other (targeting by enable label) can be 
 used at the same time to target containers.
 
+## Filter by disabling specific container names
+Monitor and update containers whose names are not in a given set of names.
+
+This can be used to exclude specific containers, when setting labels is not an option.
+The listed containers will be excluded even if they have the enable filter set to true.
+
+```text
+            Argument: --disable-containers, -x
+Environment Variable: WATCHTOWER_DISABLE_CONTAINERS
+                Type: Comma- or space-separated string list
+             Default: ""
+```
+
 ## Without updating containers
 Will only monitor for new images, send notifications and invoke
 the [pre-check/post-check hooks](https://containrrr.dev/watchtower/lifecycle-hooks/), but will __not__ update the

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -84,6 +85,13 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"e",
 		envBool("WATCHTOWER_LABEL_ENABLE"),
 		"Watch containers where the com.centurylinklabs.watchtower.enable label is true")
+
+	flags.StringSliceP(
+		"disable-containers",
+		"x",
+		// Due to issue spf13/viper#380, can't use viper.GetStringSlice:
+		regexp.MustCompile("[, ]+").Split(envString("WATCHTOWER_DISABLE_CONTAINERS"), -1),
+		"Comma-separated list of containers to explicitly exclude from watching.")
 
 	flags.StringP(
 		"log-format",
@@ -197,8 +205,8 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"",
 		false,
 		"Do health check and exit")
-  
-  flags.BoolP(
+
+	flags.BoolP(
 		"label-take-precedence",
 		"",
 		envBool("WATCHTOWER_LABEL_TAKE_PRECEDENCE"),


### PR DESCRIPTION
This adds a way to exclude containers by name, rather than having to set labels.

Resolves #1566
