### PR TITLE
chore: replace usages of ioutil

### DIFF
--- a/pkg/api/metrics/metrics_test.go
+++ b/pkg/api/metrics/metrics_test.go
@@ -2,18 +2,18 @@ package metrics_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"github.com/containrrr/watchtower/pkg/api"
 	metricsAPI "github.com/containrrr/watchtower/pkg/api/metrics"
 	"github.com/containrrr/watchtower/pkg/metrics"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const (
@@ -36,7 +36,7 @@ func getWithToken(handler http.Handler) map[string]string {
 	handler.ServeHTTP(respWriter, req)
 
 	res := respWriter.Result()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	for _, line := range strings.Split(string(body), "\n") {
 		if len(line) < 1 || line[0] == '#' {

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -3,14 +3,10 @@ package container
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
-	"github.com/containrrr/watchtower/pkg/registry"
-	"github.com/containrrr/watchtower/pkg/registry/digest"
-
-	t "github.com/containrrr/watchtower/pkg/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -18,6 +14,10 @@ import (
 	sdkClient "github.com/docker/docker/client"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+
+	"github.com/containrrr/watchtower/pkg/registry"
+	"github.com/containrrr/watchtower/pkg/registry/digest"
+	t "github.com/containrrr/watchtower/pkg/types"
 )
 
 const defaultStopSignal = "SIGTERM"
@@ -399,7 +399,7 @@ func (client dockerClient) PullImage(ctx context.Context, container t.Container)
 
 	defer response.Close()
 	// the pull request will be aborted prematurely unless the response is read
-	if _, err = ioutil.ReadAll(response); err != nil {
+	if _, err = io.ReadAll(response); err != nil {
 		log.Error(err)
 		return err
 	}


### PR DESCRIPTION
ioutil is not used anymore, in favor of io or os. in this case, io is a drop in replacement for ioutil.

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
