### PR TITLE
feat: add support for "none" scope

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -359,6 +359,11 @@ Environment Variable: WATCHTOWER_HTTP_API_PERIODIC_POLLS
 Update containers that have a `com.centurylinklabs.watchtower.scope` label set with the same value as the given argument. 
 This enables [running multiple instances](https://containrrr.dev/watchtower/running-multiple-instances).
 
+!!! note "Filter by lack of scope"
+    If you want other instances of watchtower to ignore the scoped containers, set this argument to `none`.
+    When omitted, watchtower will update all containers regardless of scope.
+
+
 ```text
             Argument: --scope
 Environment Variable: WATCHTOWER_SCOPE

--- a/docs/running-multiple-instances.md
+++ b/docs/running-multiple-instances.md
@@ -1,10 +1,11 @@
 By default, Watchtower will clean up other instances and won't allow multiple instances running on the same Docker host or swarm. It is possible to override this behavior by defining a [scope](https://containrrr.github.io/watchtower/arguments/#filter_by_scope) to each running instance. 
 
-Notice that:
--   Multiple instances can't run with the same scope;
--   An instance without a scope will clean up other running instances, even if they have a defined scope;
+!!! note
+    - Multiple instances can't run with the same scope;
+    - An instance without a scope will clean up other running instances, even if they have a defined scope;
+    - Supplying `none` as the scope will treat `com.centurylinklabs.watchtower.scope=none`, `com.centurylinklabs.watchtower.scope=` and the lack of a `com.centurylinklabs.watchtower.scope` label as the scope `none`. This effectly enables you to run both scoped and unscoped watchtower instances on the same machine.
 
-To define an instance monitoring scope, use the `--scope` argument or the `WATCHTOWER_SCOPE` environment variable on startup and set the _com.centurylinklabs.watchtower.scope_ label with the same value for the containers you want to include in this instance's scope (including the instance itself).
+To define an instance monitoring scope, use the `--scope` argument or the `WATCHTOWER_SCOPE` environment variable on startup and set the `com.centurylinklabs.watchtower.scope` label with the same value for the containers you want to include in this instance's scope (including the instance itself).
 
 For example, in a Docker Compose config file:
 
@@ -12,16 +13,29 @@ For example, in a Docker Compose config file:
 version: '3'
 
 services:
-  app-monitored-by-watchtower:
+  app-with-scope:
     image: myapps/monitored-by-watchtower
-    labels:
-      - "com.centurylinklabs.watchtower.scope=myscope"
+    labels: [ "com.centurylinklabs.watchtower.scope=myscope" ]
 
-  watchtower:
+  scoped-watchtower:
     image: containrrr/watchtower
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    volumes: [ "/var/run/docker.sock:/var/run/docker.sock" ]
     command: --interval 30 --scope myscope
-    labels:
-      - "com.centurylinklabs.watchtower.scope=myscope"
+    labels: [ "com.centurylinklabs.watchtower.scope=myscope" ] 
+
+  unscoped-app-a:
+    image: myapps/app-a
+
+  unscoped-app-b:
+    image: myapps/app-b
+    labels: [ "com.centurylinklabs.watchtower.scope=none" ]
+    
+  unscoped-app-c:
+    image: myapps/app-b
+    labels: [ "com.centurylinklabs.watchtower.scope=" ]
+    
+  unscoped-watchtower:
+    image: containrrr/watchtower
+    volumes: [ "/var/run/docker.sock:/var/run/docker.sock" ]
+    command: --interval 30 --scope none
 ```

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -138,6 +138,26 @@ func TestFilterByNoneScope(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestBuildFilterNoneScope(t *testing.T) {
+	filter, desc := BuildFilter(nil, nil, false, "none")
+
+	assert.Contains(t, desc, "without a scope")
+
+	scoped := new(mocks.FilterableContainer)
+	scoped.On("Enabled").Return(false, false)
+	scoped.On("Scope").Return("anyscope", true)
+
+	unscoped := new(mocks.FilterableContainer)
+	unscoped.On("Enabled").Return(false, false)
+	unscoped.On("Scope").Return("", false)
+
+	assert.False(t, filter(scoped))
+	assert.True(t, filter(unscoped))
+
+	scoped.AssertExpectations(t)
+	unscoped.AssertExpectations(t)
+}
+
 func TestFilterByDisabledLabel(t *testing.T) {
 	filter := FilterByDisabledLabel(NoFilter)
 	assert.NotNil(t, filter)

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -111,6 +111,33 @@ func TestFilterByScope(t *testing.T) {
 	container.AssertExpectations(t)
 }
 
+func TestFilterByNoneScope(t *testing.T) {
+	scope := "none"
+
+	filter := FilterByScope(scope, NoFilter)
+	assert.NotNil(t, filter)
+
+	container := new(mocks.FilterableContainer)
+	container.On("Scope").Return("anyscope", true)
+	assert.False(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Scope").Return("", false)
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Scope").Return("", true)
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("Scope").Return("none", true)
+	assert.True(t, filter(container))
+	container.AssertExpectations(t)
+}
+
 func TestFilterByDisabledLabel(t *testing.T) {
 	filter := FilterByDisabledLabel(NoFilter)
 	assert.NotNil(t, filter)


### PR DESCRIPTION
This PR adds a special "none" scope to watchtower that matches containers without a scope label, a scope label set to `none`, or a scope label set to an empty string (`com.centurylinklabs.watchtower.scope=`).

Effectively, this enables you to run both scoped and unscoped version of watchtower simultaneously.

Fixes #1788 
Fixes #1541
