### PR TITLE
fix: use new healthcheck config if not overridden

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -304,6 +304,27 @@ func (c Container) GetCreateConfig() *dockercontainer.Config {
 		}
 	}
 
+	// Clear HEALTHCHECK configuration (if default)
+	if util.SliceEqual(config.Healthcheck.Test, imageConfig.Healthcheck.Test) {
+		config.Healthcheck.Test = nil
+	}
+
+	if config.Healthcheck.Retries == imageConfig.Healthcheck.Retries {
+		config.Healthcheck.Retries = 0
+	}
+
+	if config.Healthcheck.Interval == imageConfig.Healthcheck.Interval {
+		config.Healthcheck.Interval = 0
+	}
+
+	if config.Healthcheck.Timeout == imageConfig.Healthcheck.Timeout {
+		config.Healthcheck.Timeout = 0
+	}
+
+	if config.Healthcheck.StartPeriod == imageConfig.Healthcheck.StartPeriod {
+		config.Healthcheck.StartPeriod = 0
+	}
+
 	config.Env = util.SliceSubtract(config.Env, imageConfig.Env)
 
 	config.Labels = util.StringMapSubtract(config.Labels, imageConfig.Labels)

--- a/pkg/container/container_mock_test.go
+++ b/pkg/container/container_mock_test.go
@@ -21,7 +21,8 @@ func MockContainer(updates ...MockContainerUpdate) *Container {
 		},
 	}
 	image := types.ImageInspect{
-		ID: "image_id",
+		ID:     "image_id",
+		Config: &dockerContainer.Config{},
 	}
 
 	for _, update := range updates {
@@ -62,5 +63,17 @@ func WithLabels(labels map[string]string) MockContainerUpdate {
 func WithContainerState(state types.ContainerState) MockContainerUpdate {
 	return func(cnt *types.ContainerJSON, img *types.ImageInspect) {
 		cnt.State = &state
+	}
+}
+
+func WithHealthcheck(healthConfig dockerContainer.HealthConfig) MockContainerUpdate {
+	return func(cnt *types.ContainerJSON, img *types.ImageInspect) {
+		cnt.Config.Healthcheck = &healthConfig
+	}
+}
+
+func WithImageHealthcheck(healthConfig dockerContainer.HealthConfig) MockContainerUpdate {
+	return func(cnt *types.ContainerJSON, img *types.ImageInspect) {
+		img.Config.Healthcheck = &healthConfig
 	}
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"github.com/containrrr/watchtower/pkg/types"
+	dc "github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -64,6 +65,63 @@ var _ = Describe("the container", func() {
 				c.containerInfo.Config.ExposedPorts = map[nat.Port]struct{}{"80/tcp": {}}
 				err := c.VerifyConfiguration()
 				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+	Describe("GetCreateConfig", func() {
+		When("container healthcheck config is equal to image config", func() {
+			It("should return empty healthcheck values", func() {
+				c := MockContainer(WithHealthcheck(dc.HealthConfig{
+					Test: []string{"/usr/bin/sleep", "1s"},
+				}), WithImageHealthcheck(dc.HealthConfig{
+					Test: []string{"/usr/bin/sleep", "1s"},
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{}))
+
+				c = MockContainer(WithHealthcheck(dc.HealthConfig{
+					Timeout: 30,
+				}), WithImageHealthcheck(dc.HealthConfig{
+					Timeout: 30,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{}))
+
+				c = MockContainer(WithHealthcheck(dc.HealthConfig{
+					StartPeriod: 30,
+				}), WithImageHealthcheck(dc.HealthConfig{
+					StartPeriod: 30,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{}))
+
+				c = MockContainer(WithHealthcheck(dc.HealthConfig{
+					Retries: 30,
+				}), WithImageHealthcheck(dc.HealthConfig{
+					Retries: 30,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{}))
+			})
+		})
+		When("container healthcheck config is different to image config", func() {
+			It("should return the container healthcheck values", func() {
+				c := MockContainer(WithHealthcheck(dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "1s"},
+					Interval:    30,
+					Timeout:     30,
+					StartPeriod: 10,
+					Retries:     2,
+				}), WithImageHealthcheck(dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "10s"},
+					Interval:    10,
+					Timeout:     60,
+					StartPeriod: 30,
+					Retries:     10,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "1s"},
+					Interval:    30,
+					Timeout:     30,
+					StartPeriod: 10,
+					Retries:     2,
+				}))
 			})
 		})
 	})


### PR DESCRIPTION
This PR will clear out the create container healthcheck configuration if it's equal to the original image's configuration. Doing this allows any new configuration from the updated image to be used instead.

Fixes #1601 