### PR TITLE
fix: handle missing healthcheck keys in config

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -305,24 +305,26 @@ func (c Container) GetCreateConfig() *dockercontainer.Config {
 	}
 
 	// Clear HEALTHCHECK configuration (if default)
-	if util.SliceEqual(config.Healthcheck.Test, imageConfig.Healthcheck.Test) {
-		config.Healthcheck.Test = nil
-	}
+	if config.Healthcheck != nil && imageConfig.Healthcheck != nil {
+		if util.SliceEqual(config.Healthcheck.Test, imageConfig.Healthcheck.Test) {
+			config.Healthcheck.Test = nil
+		}
 
-	if config.Healthcheck.Retries == imageConfig.Healthcheck.Retries {
-		config.Healthcheck.Retries = 0
-	}
+		if config.Healthcheck.Retries == imageConfig.Healthcheck.Retries {
+			config.Healthcheck.Retries = 0
+		}
 
-	if config.Healthcheck.Interval == imageConfig.Healthcheck.Interval {
-		config.Healthcheck.Interval = 0
-	}
+		if config.Healthcheck.Interval == imageConfig.Healthcheck.Interval {
+			config.Healthcheck.Interval = 0
+		}
 
-	if config.Healthcheck.Timeout == imageConfig.Healthcheck.Timeout {
-		config.Healthcheck.Timeout = 0
-	}
+		if config.Healthcheck.Timeout == imageConfig.Healthcheck.Timeout {
+			config.Healthcheck.Timeout = 0
+		}
 
-	if config.Healthcheck.StartPeriod == imageConfig.Healthcheck.StartPeriod {
-		config.Healthcheck.StartPeriod = 0
+		if config.Healthcheck.StartPeriod == imageConfig.Healthcheck.StartPeriod {
+			config.Healthcheck.StartPeriod = 0
+		}
 	}
 
 	config.Env = util.SliceSubtract(config.Env, imageConfig.Env)

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -124,6 +124,36 @@ var _ = Describe("the container", func() {
 				}))
 			})
 		})
+		When("container healthcheck config is empty", func() {
+			It("should not panic", func() {
+				c := MockContainer(WithImageHealthcheck(dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "10s"},
+					Interval:    10,
+					Timeout:     60,
+					StartPeriod: 30,
+					Retries:     10,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(BeNil())
+			})
+		})
+		When("container image healthcheck config is empty", func() {
+			It("should not panic", func() {
+				c := MockContainer(WithHealthcheck(dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "1s"},
+					Interval:    30,
+					Timeout:     30,
+					StartPeriod: 10,
+					Retries:     2,
+				}))
+				Expect(c.GetCreateConfig().Healthcheck).To(Equal(&dc.HealthConfig{
+					Test:        []string{"/usr/bin/sleep", "1s"},
+					Interval:    30,
+					Timeout:     30,
+					StartPeriod: 10,
+					Retries:     2,
+				}))
+			})
+		})
 	})
 	When("asked for metadata", func() {
 		var c *Container


### PR DESCRIPTION
Only perform the `container.GetCreateConfig` default value override dance for `healthcheck` when it's actually present in both container and image config.

Fixes #1809 

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
