### PR TITLE
chore: fix json syntax error in .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -847,7 +847,7 @@
       "login": "andriibratanin",
       "name": "Andrii Bratanin",
       "avatar_url": "https://avatars.githubusercontent.com/u/20169213?v=4",
-      "profile": "https://github.com/andriibratanin",
+      "profile": "https://github.com/andriibratanin"
     },
     {
       "login": "IAmTamal",


### PR DESCRIPTION
:bug: This bug seems to be the reason for the "all contributors unparseable json" result in the readme as below:

![image](https://github.com/containrrr/watchtower/assets/3691490/7b634206-315f-4a45-96dc-ef866d9af453)
