### PR TITLE
Add container name to new image found log, useful when running monitor-only

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -343,7 +343,7 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 		return false, currentImageID, nil
 	}
 
-	log.Infof("Found new %s image (%s)", imageName, newImageID.ShortID())
+	log.Infof("Found new %s image (%s) for container %s", imageName, newImageID.ShortID(), container.Name())
 	return true, newImageID, nil
 }
 


### PR DESCRIPTION
- What your PR contributes
  Simply added the container name to the "Found new image" log, because in monitor-only it's not clear which container needs to be recreated, also there are duplicate log lines if the same image is used in multiple containers (MariaDB etc). I added it to the end of the message to limit issues if people are parsing the log message in their workflows.

- Which issues it solves
  No issue, I can open one if required but for such a tiny change I thought any discussion could happen here.

- Tests that verify the code your contributing
  Unable to get a dev env set up, there are no instructions on the project. Unable to build a test docker image that runs. The Go compiler doesn't complain though, which from such a small change I would expect it to if I'd gone wrong.

- Updates to the documentation
  None required