### PR TITLE
fix(ci): fix incorrect actions config

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: 1.20.x
       - name: Build
         run: ./build.sh
   test:
@@ -24,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: 1.20.x
       - name: Test
         run: go test -v -coverprofile coverage.out -covermode atomic ./... 
       - name: Publish coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: Release (Production)
 
 on:
   workflow_dispatch: {}
-  release:
-    types:
-      - created
+  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - '**/v[0-9]+.[0-9]+.[0-9]+'
@@ -59,7 +57,7 @@ jobs:
       - lint
     env:
       CGO_ENABLED: 0
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This fixes three problems:
 - setup-go in the dev-release tried to install go v1.2 instead of v1.20, since it's parsed as a number
 - when setting the dev version, not enough commits where fetched to feed `git describe`
 - release builds were triggered on release creation instead of tag creation and with a incorrect tag selector
