### PR TITLE
Adding parameter to allow containers to be updated only after some number of days have passed since the new image has been published

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	disableContainers []string
 	notifier          t.Notifier
 	timeout           time.Duration
+	delayDays         int
 	lifecycleHooks    bool
 	rollingRestart    bool
 	scope             string
@@ -96,6 +97,7 @@ func PreRun(cmd *cobra.Command, _ []string) {
 
 	enableLabel, _ = f.GetBool("label-enable")
 	disableContainers, _ = f.GetStringSlice("disable-containers")
+	delayDays, _ = f.GetInt("delay-days")
 	lifecycleHooks, _ = f.GetBool("enable-lifecycle-hooks")
 	rollingRestart, _ = f.GetBool("rolling-restart")
 	scope, _ = f.GetString("scope")
@@ -364,6 +366,7 @@ func runUpdatesWithNotifications(filter t.Filter) *metrics.Metric {
 		NoRestart:       noRestart,
 		Timeout:         timeout,
 		MonitorOnly:     monitorOnly,
+		DelayDays:       delayDays,
 		LifecycleHooks:  lifecycleHooks,
 		RollingRestart:  rollingRestart,
 		LabelPrecedence: labelPrecedence,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -290,6 +290,10 @@ func writeStartupMessage(c *cobra.Command, sched time.Time, filtering string) {
 		until := formatDuration(time.Until(sched))
 		startupLog.Info("Scheduling first run: " + sched.Format("2006-01-02 15:04:05 -0700 MST"))
 		startupLog.Info("Note that the first check will be performed in " + until)
+		delayDays, _ = c.PersistentFlags().GetInt("delay-days")
+		if delayDays > 0 {
+			startupLog.Infof("Container updates will be delayed until %d day(s) after image creation.", delayDays)
+		}
 	} else if runOnce, _ := c.PersistentFlags().GetBool("run-once"); runOnce {
 		startupLog.Info("Running a one time update.")
 	} else {

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -381,6 +381,16 @@ Environment Variable: WATCHTOWER_HTTP_API_METRICS
              Default: false
 ```
 
+## Delayed Update
+Only update container to latest version of image if some number of days have passed since it has been published. This option may be useful for those who wish to avoid updating prior to the new version having some time in the field prior to updating in case there are critical defects found and released in a subsequent version.
+
+```text
+            Argument: --delay-days
+Environment Variable: WATCHTOWER_DELAY_DAYS
+                Type: Integer
+             Default: false
+```
+
 ## Scheduling
 [Cron expression](https://pkg.go.dev/github.com/robfig/cron@v1.2.0?tab=doc#hdr-CRON_Expression_Format) in 6 fields (rather than the traditional 5) which defines when and how often to check for new images. Either `--interval` or the schedule expression
 can be defined, but not both. An example: `--schedule "0 0 4 * * *"`

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -381,12 +381,12 @@ Environment Variable: WATCHTOWER_HTTP_API_METRICS
              Default: false
 ```
 
-## Delayed Update
+## Deferred Update
 Only update container to latest version of image if some number of days have passed since it has been published. This option may be useful for those who wish to avoid updating prior to the new version having some time in the field prior to updating in case there are critical defects found and released in a subsequent version.
 
 ```text
-            Argument: --delay-days
-Environment Variable: WATCHTOWER_DELAY_DAYS
+            Argument: --defer-days
+Environment Variable: WATCHTOWER_DEFER_DAYS
                 Type: Integer
              Default: false
 ```

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -82,7 +82,7 @@ func CreateMockContainerWithDigest(id string, name string, image string, created
 // CreateMockContainerWithDigest should only be used for testing
 func CreateMockContainerWithImageCreatedTime(id string, name string, image string, created time.Time, imageCreated time.Time) wt.Container {
 	c := CreateMockContainer(id, name, image, created)
-	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339)
+	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339Nano)
 	return c
 }
 

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -79,6 +79,13 @@ func CreateMockContainerWithDigest(id string, name string, image string, created
 	return c
 }
 
+// CreateMockContainerWithDigest should only be used for testing
+func CreateMockContainerWithImageCreatedTime(id string, name string, image string, created time.Time, imageCreated time.Time) wt.Container {
+	c := CreateMockContainer(id, name, image, created)
+	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339)
+	return c
+}
+
 // CreateMockContainerWithConfig creates a container substitute valid for testing
 func CreateMockContainerWithConfig(id string, name string, image string, running bool, restarting bool, created time.Time, config *dockerContainer.Config) wt.Container {
 	content := types.ContainerJSON{

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -89,7 +89,7 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 	UpdateImplicitRestart(containers)
 
 	// containersToUpdate will contain all containers, not just those that need to be updated. The "stale" flag is checked via container.ToRestart()
-	// within stopContainersInReversedOrder and restartContainersInSortedOrder to skip over containers with stale set to false (unless LinkedToRestarting set)
+	// within stopContainersInReversedOrder and restartContainersInSortedOrder to skip containers with stale set to false (unless LinkedToRestarting set)
 	var containersToUpdate []types.Container
 	for _, c := range containers {
 		if !c.IsMonitorOnly(params) {
@@ -286,7 +286,7 @@ func linkedContainerMarkedForRestart(links []string, containers []types.Containe
 }
 
 // Finds the difference between now and a given date, in full days. Input date is expected to originate
-// from an image's Created attribute, but since these are not always in ISO 8601 with the same number of
+// from an image's Created attribute in ISO 8601, but since these do not always contain the same number of
 // digits for milliseconds, the function also accounts for variations.
 func getImageAgeDays(imageCreatedDateTime string) (int, error) {
 

--- a/internal/actions/update.go
+++ b/internal/actions/update.go
@@ -2,6 +2,8 @@ package actions
 
 import (
 	"errors"
+	"strings"
+	"time"
 
 	"github.com/containrrr/watchtower/internal/util"
 	"github.com/containrrr/watchtower/pkg/container"
@@ -33,13 +35,23 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 	staleCheckFailed := 0
 
 	for i, targetContainer := range containers {
+		// stale will be true if there is a more recent image than the current container is using
 		stale, newestImage, err := client.IsContainerStale(targetContainer, params)
 		shouldUpdate := stale && !params.NoRestart && !targetContainer.IsMonitorOnly(params)
+		imageUpdateDelayResolved := true
+		imageAgeDays := 0
 		if err == nil && shouldUpdate {
-			// Check to make sure we have all the necessary information for recreating the container
+			// Check to make sure we have all the necessary information for recreating the container, including ImageInfo
 			err = targetContainer.VerifyConfiguration()
-			// If the image information is incomplete and trace logging is enabled, log it for further diagnosis
-			if err != nil && log.IsLevelEnabled(log.TraceLevel) {
+			if err == nil {
+				if params.DelayDays > 0 {
+					imageAgeDays, err := getImageAgeDays(targetContainer.ImageInfo().Created)
+					if err == nil {
+						imageUpdateDelayResolved = imageAgeDays >= params.DelayDays
+					}
+				}
+			} else if log.IsLevelEnabled(log.TraceLevel) {
+				// If the image information is incomplete and trace logging is enabled, log it for further diagnosis
 				imageInfo := targetContainer.ImageInfo()
 				log.Tracef("Image info: %#v", imageInfo)
 				log.Tracef("Container info: %#v", targetContainer.ContainerInfo())
@@ -54,6 +66,11 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 			stale = false
 			staleCheckFailed++
 			progress.AddSkipped(targetContainer, err)
+		} else if !imageUpdateDelayResolved {
+			log.Infof("New image found for %s that was created %d day(s) ago but update delayed until %d day(s) after creation", targetContainer.Name(), imageAgeDays, params.DelayDays)
+			// technically the container is stale but we set it to false here because it is this stale flag that tells downstream methods whether to perform the update
+			stale = false
+			progress.AddScanned(targetContainer, newestImage)
 		} else {
 			progress.AddScanned(targetContainer, newestImage)
 		}
@@ -71,6 +88,8 @@ func Update(client container.Client, params types.UpdateParams) (types.Report, e
 
 	UpdateImplicitRestart(containers)
 
+	// containersToUpdate will contain all containers, not just those that need to be updated. The "stale" flag is checked via container.ToRestart()
+	// within stopContainersInReversedOrder and restartContainersInSortedOrder to skip over containers with stale set to false (unless LinkedToRestarting set)
 	var containersToUpdate []types.Container
 	for _, c := range containers {
 		if !c.IsMonitorOnly(params) {
@@ -264,4 +283,28 @@ func linkedContainerMarkedForRestart(links []string, containers []types.Containe
 		}
 	}
 	return ""
+}
+
+// Finds the difference between now and a given date, in full days. Input date is expected to originate
+// from an image's Created attribute, but since these are not always in ISO 8601 with the same number of
+// digits for milliseconds, the function also accounts for variations.
+func getImageAgeDays(imageCreatedDateTime string) (int, error) {
+
+	// Date strings sometimes vary in how many digits after the decimal point are present. If present, drop millisecond portion to standardize.
+	dotIndex := strings.Index(imageCreatedDateTime, ".")
+	if dotIndex != -1 {
+		imageCreatedDateTime = imageCreatedDateTime[:dotIndex] + "Z"
+	}
+
+	// Define the layout string for the date format without milliseconds
+	layout := "2006-01-02T15:04:05Z"
+	imageCreatedDate, error := time.Parse(layout, imageCreatedDateTime)
+
+	if error != nil {
+		log.Errorf("Error parsing imageCreatedDateTime date (%s). Error: %s", imageCreatedDateTime, error)
+		return -1, error
+	}
+
+	return int(time.Since(imageCreatedDate).Hours() / 24), nil
+
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -147,6 +147,12 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		envBool("WATCHTOWER_LIFECYCLE_HOOKS"),
 		"Enable the execution of commands triggered by pre- and post-update lifecycle hooks")
 
+	flags.IntP(
+		"delay-days",
+		"0",
+		envInt("WATCHTOWER_DELAY_DAYS"),
+		"Number of days to wait for new image version to be in place prior to installing it")
+
 	flags.BoolP(
 		"rolling-restart",
 		"",

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -148,9 +148,9 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Enable the execution of commands triggered by pre- and post-update lifecycle hooks")
 
 	flags.IntP(
-		"delay-days",
+		"defer-days",
 		"0",
-		envInt("WATCHTOWER_DELAY_DAYS"),
+		envInt("WATCHTOWER_DEFER_DAYS"),
 		"Number of days to wait for new image version to be in place prior to installing it")
 
 	flags.BoolP(

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -278,9 +278,9 @@ func TestProcessFlagAliasesInvalidPorcelaineVersion(t *testing.T) {
 	})
 }
 
-func TestFlagsArePrecentInDocumentation(t *testing.T) {
+func TestFlagsArePresentInDocumentation(t *testing.T) {
 
-	// Legacy notifcations are ignored, since they are (soft) deprecated
+	// Legacy notifications are ignored, since they are (soft) deprecated
 	ignoredEnvs := map[string]string{
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_EMOJI": "legacy",
 		"WATCHTOWER_NOTIFICATION_SLACK_ICON_URL":   "legacy",

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -325,10 +325,25 @@ func (client dockerClient) IsContainerStale(container t.Container, params t.Upda
 		return false, container.SafeImageID(), err
 	}
 
-	return client.HasNewImage(ctx, container)
+	return client.HasNewImage(ctx, container, params)
 }
 
-func (client dockerClient) HasNewImage(ctx context.Context, container t.Container) (hasNew bool, latestImage t.ImageID, err error) {
+// Date strings sometimes vary in how many digits after the decimal point are present. This function
+// standardizes them by removing the milliseconds.
+func truncateMilliseconds(dateString string) string {
+	// Find the position of the dot (.) in the date string
+	dotIndex := strings.Index(dateString, ".")
+
+	// If the dot is found, truncate the string before the dot
+	if dotIndex != -1 {
+		return dateString[:dotIndex] + "Z"
+	}
+
+	// If the dot is not found, return the original string
+	return dateString
+}
+
+func (client dockerClient) HasNewImage(ctx context.Context, container t.Container, params t.UpdateParams) (hasNew bool, latestImage t.ImageID, err error) {
 	currentImageID := t.ImageID(container.ContainerInfo().ContainerJSONBase.Image)
 	imageName := container.ImageName()
 
@@ -339,8 +354,28 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 
 	newImageID := t.ImageID(newImageInfo.ID)
 	if newImageID == currentImageID {
-		log.Debugf("No new images found for %s", container.Name())
+		log.Debugf("No new images found for %s [ imageID %s ]", container.Name(), newImageID.ShortID())
 		return false, currentImageID, nil
+	}
+
+	// Disabled by default
+	if params.DelayDays > 0 {
+		// Define the layout string for the date format without milliseconds
+		layout := "2006-01-02T15:04:05Z"
+		newImageDate, error := time.Parse(layout, truncateMilliseconds(newImageInfo.Created))
+
+		if error != nil {
+			log.Errorf("Error parsing Created date (%s) for container %s latest label. Error: %s", newImageInfo.Created, container.Name(), error)
+			return false, currentImageID, nil
+		} else {
+			requiredDays := params.DelayDays
+			diffDays := int(time.Since(newImageDate).Hours() / 24)
+
+			if diffDays < requiredDays {
+				log.Infof("New image found for %s that is %d days since publication but update delayed until %d days", container.Name(), diffDays, requiredDays)
+				return false, currentImageID, nil
+			}
+		}
 	}
 
 	log.Infof("Found new %s image (%s)", imageName, newImageID.ShortID())

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -354,7 +354,7 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 
 	newImageID := t.ImageID(newImageInfo.ID)
 	if newImageID == currentImageID {
-		log.Debugf("No new images found for %s [ imageID %s ]", container.Name(), newImageID.ShortID())
+		log.Debugf("No new images found for %s", container.Name())
 		return false, currentImageID, nil
 	}
 

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -372,7 +372,7 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 			diffDays := int(time.Since(newImageDate).Hours() / 24)
 
 			if diffDays < requiredDays {
-				log.Infof("New image found for %s that is %d days since publication but update delayed until %d days", container.Name(), diffDays, requiredDays)
+				log.Infof("New image found for %s that was created %d day(s) ago but update delayed until %d day(s) after creation", container.Name(), diffDays, requiredDays)
 				return false, currentImageID, nil
 			}
 		}

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -325,10 +325,10 @@ func (client dockerClient) IsContainerStale(container t.Container, params t.Upda
 		return false, container.SafeImageID(), err
 	}
 
-	return client.HasNewImage(ctx, container, params)
+	return client.HasNewImage(ctx, container)
 }
 
-func (client dockerClient) HasNewImage(ctx context.Context, container t.Container, params t.UpdateParams) (hasNew bool, latestImage t.ImageID, err error) {
+func (client dockerClient) HasNewImage(ctx context.Context, container t.Container) (hasNew bool, latestImage t.ImageID, err error) {
 	currentImageID := t.ImageID(container.ContainerInfo().ContainerJSONBase.Image)
 	imageName := container.ImageName()
 

--- a/pkg/notifications/json.go
+++ b/pkg/notifications/json.go
@@ -23,12 +23,13 @@ func (d Data) MarshalJSON() ([]byte, error) {
 	var report jsonMap
 	if d.Report != nil {
 		report = jsonMap{
-			`scanned`: marshalReports(d.Report.Scanned()),
-			`updated`: marshalReports(d.Report.Updated()),
-			`failed`:  marshalReports(d.Report.Failed()),
-			`skipped`: marshalReports(d.Report.Skipped()),
-			`stale`:   marshalReports(d.Report.Stale()),
-			`fresh`:   marshalReports(d.Report.Fresh()),
+			`scanned`:  marshalReports(d.Report.Scanned()),
+			`updated`:  marshalReports(d.Report.Updated()),
+			`deferred`: marshalReports(d.Report.Deferred()),
+			`failed`:   marshalReports(d.Report.Failed()),
+			`skipped`:  marshalReports(d.Report.Skipped()),
+			`stale`:    marshalReports(d.Report.Stale()),
+			`fresh`:    marshalReports(d.Report.Fresh()),
 		}
 	}
 

--- a/pkg/notifications/json_test.go
+++ b/pkg/notifications/json_test.go
@@ -21,6 +21,7 @@ var _ = Describe("JSON template", func() {
 		],
 		"host": "Mock",
 		"report": {
+		"deferred": [],
 		"failed": [
 			{
 				"currentImageId": "01d210000000",
@@ -110,7 +111,7 @@ var _ = Describe("JSON template", func() {
 		},
 		"title": "Watchtower updates on Mock"
 }`
-				data := mockDataFromStates(s.UpdatedState, s.FreshState, s.FailedState, s.SkippedState, s.UpdatedState)
+				data := mockDataFromStates(s.UpdatedState, s.DeferredState, s.FreshState, s.FailedState, s.SkippedState, s.UpdatedState)
 				Expect(getTemplatedResult(`json.v1`, false, data)).To(MatchJSON(expected))
 			})
 		})

--- a/pkg/notifications/preview/data/data.go
+++ b/pkg/notifications/preview/data/data.go
@@ -72,6 +72,8 @@ func (pb *previewData) addContainer(c containerStatus) {
 		pb.report.scanned = append(pb.report.scanned, &c)
 	case UpdatedState:
 		pb.report.updated = append(pb.report.updated, &c)
+	case DeferredState:
+		pb.report.deferred = append(pb.report.deferred, &c)
 	case FailedState:
 		pb.report.failed = append(pb.report.failed, &c)
 	case SkippedState:

--- a/pkg/notifications/preview/data/report.go
+++ b/pkg/notifications/preview/data/report.go
@@ -10,12 +10,13 @@ import (
 type State string
 
 const (
-	ScannedState State = "scanned"
-	UpdatedState State = "updated"
-	FailedState  State = "failed"
-	SkippedState State = "skipped"
-	StaleState   State = "stale"
-	FreshState   State = "fresh"
+	ScannedState  State = "scanned"
+	UpdatedState  State = "updated"
+	DeferredState State = "deferred"
+	FailedState   State = "failed"
+	SkippedState  State = "skipped"
+	StaleState    State = "stale"
+	FreshState    State = "fresh"
 )
 
 // StatesFromString parses a string of state characters and returns a slice of the corresponding report states
@@ -27,6 +28,8 @@ func StatesFromString(str string) []State {
 			states = append(states, ScannedState)
 		case 'u':
 			states = append(states, UpdatedState)
+		case 'd':
+			states = append(states, DeferredState)
 		case 'e':
 			states = append(states, FailedState)
 		case 'k':
@@ -43,12 +46,13 @@ func StatesFromString(str string) []State {
 }
 
 type report struct {
-	scanned []types.ContainerReport
-	updated []types.ContainerReport
-	failed  []types.ContainerReport
-	skipped []types.ContainerReport
-	stale   []types.ContainerReport
-	fresh   []types.ContainerReport
+	scanned  []types.ContainerReport
+	updated  []types.ContainerReport
+	deferred []types.ContainerReport
+	failed   []types.ContainerReport
+	skipped  []types.ContainerReport
+	stale    []types.ContainerReport
+	fresh    []types.ContainerReport
 }
 
 func (r *report) Scanned() []types.ContainerReport {
@@ -56,6 +60,9 @@ func (r *report) Scanned() []types.ContainerReport {
 }
 func (r *report) Updated() []types.ContainerReport {
 	return r.updated
+}
+func (r *report) Deferred() []types.ContainerReport {
+	return r.deferred
 }
 func (r *report) Failed() []types.ContainerReport {
 	return r.failed
@@ -87,6 +94,7 @@ func (r *report) All() []types.ContainerReport {
 	}
 
 	appendUnique(r.updated)
+	appendUnique(r.deferred)
 	appendUnique(r.failed)
 	appendUnique(r.skipped)
 	appendUnique(r.stale)

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -12,6 +12,7 @@ const (
 	SkippedState
 	ScannedState
 	UpdatedState
+	DeferredState
 	FailedState
 	FreshState
 	StaleState
@@ -70,6 +71,8 @@ func (u *ContainerStatus) State() string {
 		return "Scanned"
 	case UpdatedState:
 		return "Updated"
+	case DeferredState:
+		return "Deferred"
 	case FailedState:
 		return "Failed"
 	case FreshState:

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -50,6 +50,11 @@ func (m Progress) MarkForUpdate(containerID types.ContainerID) {
 	m[containerID].state = UpdatedState
 }
 
+// MarkForUpdate marks the container identified by containerID for deferral
+func (m Progress) MarkDeferred(containerID types.ContainerID) {
+	m[containerID].state = DeferredState
+}
+
 // Report creates a new Report from a Progress instance
 func (m Progress) Report() types.Report {
 	return NewReport(m)

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -4,6 +4,7 @@ package types
 type Report interface {
 	Scanned() []ContainerReport
 	Updated() []ContainerReport
+	Deferred() []ContainerReport
 	Failed() []ContainerReport
 	Skipped() []ContainerReport
 	Stale() []ContainerReport

--- a/pkg/types/update_params.go
+++ b/pkg/types/update_params.go
@@ -12,7 +12,7 @@ type UpdateParams struct {
 	Timeout         time.Duration
 	MonitorOnly     bool
 	NoPull          bool
-	DelayDays       int
+	DeferDays       int
 	LifecycleHooks  bool
 	RollingRestart  bool
 	LabelPrecedence bool

--- a/pkg/types/update_params.go
+++ b/pkg/types/update_params.go
@@ -11,7 +11,8 @@ type UpdateParams struct {
 	NoRestart       bool
 	Timeout         time.Duration
 	MonitorOnly     bool
-	NoPull			bool
+	NoPull          bool
+	DelayDays       int
 	LifecycleHooks  bool
 	RollingRestart  bool
 	LabelPrecedence bool

--- a/tplprev/main.go
+++ b/tplprev/main.go
@@ -18,7 +18,7 @@ func main() {
 	var states string
 	var entries string
 
-	flag.StringVar(&states, "states", "cccuuueeekkktttfff", "sCanned, Updated, failEd, sKipped, sTale, Fresh")
+	flag.StringVar(&states, "states", "cccuuudddeeekkktttfff", "sCanned, Updated, Deferred, failEd, sKipped, sTale, Fresh")
 	flag.StringVar(&entries, "entries", "ewwiiidddd", "Fatal,Error,Warn,Info,Debug,Trace")
 
 	flag.Parse()


### PR DESCRIPTION
This PR adds a new optional flag --delay-days that tells watchtower to wait to update a container to a new image until some number of days have passed since the image was published. This is useful for scenarios where images are published with a major defect that is only noticed after it has been installed in some portion of the user base. Instead of automatically updating the same day as such images are published, watchtower can now wait a day, a week, or however long the user wishes to be more certain that the image has been installed on many other people's machines and hasn't had a serious issue that caused the devs to publish a new defect-fixing image. Therefore, watchtower can still provide the same benefit of keeping the user's containers up-to-date, but with reduced risk.

closes #1879 

Testing with

`watchtower  --log-level info --interval 30 --delay-days 1
`

I started with 4 containers running locally, all of which were on latest. The usual watchtower output is seen, with a note at startup indicating that delayed updates are active and for how many days:

> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Watchtower "
> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Using no notifications"
> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Checking all containers (except explicitly disabled with label)"
> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Scheduling first run: 2023-12-18 02:40:24 +0000 UTC"
> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Note that the first check will be performed in 29 seconds"
> 2023-12-17 20:39:54 time="2023-12-18T02:39:54Z" level=info msg="Container updates will be delayed until 1 day(s) after image creation."
> 2023-12-17 20:40:25 time="2023-12-18T02:40:25Z" level=info msg="Session done" Failed=0 Scanned=4 Updated=0 notify=no
> 2023-12-17 20:40:54 time="2023-12-18T02:40:54Z" level=info msg="Session done" Failed=0 Scanned=4 Updated=0 notify=no

Then I modified a line in one of the apps, then issued a new docker build and push for the new version, making it the latest. Now, at each interval, watchtower sees that the new image exists but it hasn't yet been a full day since it was published so it doesn't perform the update but does indicate this reason in the log:

> 2023-12-17 20:41:54 time="2023-12-18T02:41:54Z" level=info msg="New image found for /my-local-app that was created 0 day(s) ago but update delayed until 1 day(s) after creation"
> 2023-12-17 20:41:54 time="2023-12-18T02:41:54Z" level=info msg="Session done" Failed=0 Scanned=4 Updated=0 notify=no

After that version gets to be 1 full day old, it will update as normal. I didn't retain my logs for that happening last night in my testing, but it did work. I'll drop a comment on this PR once my latest run gets to that point again so you can see the logs for that.

If running watchtower without the --delay-days flag set, or with a value of 0, it operates the normal way. I can supply a log of that too if you like.

As this is my first contribution to this repo, please just let me know if you need any other info or changes.