### PR TITLE
Add OCI image labels

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@ LABEL "org.opencontainers.image.url"="https://containrrr.dev/watchtower/" \
       "org.opencontainers.image.licenses"="Apache-2.0" \
 # unsure about capitalization
       "org.opencontainers.image.title"="watchtower" \
-      "org.opencontainers.image.title"="A process for automating Docker container base image updates." \
+      "org.opencontainers.image.description"="A process for automating Docker container base image updates." \
 # The version might be forgotten. The version could be extraced into a `ARG` before the initial `FROM` or removed.
       "org.opencontainers.image.base.name"="alpine:3.19.0"
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -6,6 +6,15 @@ RUN apk add --no-cache \
 
 FROM scratch
 LABEL "com.centurylinklabs.watchtower"="true"
+LABEL "org.opencontainers.image.url"="https://containrrr.dev/watchtower/" \
+      "org.opencontainers.image.documentation"="https://containrrr.dev/watchtower/" \
+      "org.opencontainers.image.source"="https://github.com/containrrr/watchtower" \
+      "org.opencontainers.image.licenses"="Apache-2.0" \
+# unsure about capitalization
+      "org.opencontainers.image.title"="watchtower" \
+      "org.opencontainers.image.title"="A process for automating Docker container base image updates." \
+# The version might be forgotten. The version could be extraced into a `ARG` before the initial `FROM` or removed.
+      "org.opencontainers.image.base.name"="alpine:3.19.0"
 
 COPY --from=alpine \
     /etc/ssl/certs/ca-certificates.crt \

--- a/dockerfiles/Dockerfile.self-contained
+++ b/dockerfiles/Dockerfile.self-contained
@@ -29,6 +29,13 @@ RUN \
 FROM scratch
 
 LABEL "com.centurylinklabs.watchtower"="true"
+LABEL "org.opencontainers.image.url"="https://containrrr.dev/watchtower/" \
+      "org.opencontainers.image.documentation"="https://containrrr.dev/watchtower/" \
+      "org.opencontainers.image.source"="https://github.com/containrrr/watchtower" \
+      "org.opencontainers.image.licenses"="Apache-2.0" \
+      "org.opencontainers.image.title"="watchtower" \
+      "org.opencontainers.image.title"="A process for automating Docker container base image updates." \
+      "org.opencontainers.image.base.name"="alpine"
 
 # copy files from other container
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/dockerfiles/Dockerfile.self-contained
+++ b/dockerfiles/Dockerfile.self-contained
@@ -34,7 +34,7 @@ LABEL "org.opencontainers.image.url"="https://containrrr.dev/watchtower/" \
       "org.opencontainers.image.source"="https://github.com/containrrr/watchtower" \
       "org.opencontainers.image.licenses"="Apache-2.0" \
       "org.opencontainers.image.title"="watchtower" \
-      "org.opencontainers.image.title"="A process for automating Docker container base image updates." \
+      "org.opencontainers.image.description"="A process for automating Docker container base image updates." \
       "org.opencontainers.image.base.name"="alpine"
 
 # copy files from other container

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -30,7 +30,11 @@ archives:
 dockers:
   -
     use_buildx: true
-    build_flag_templates: [ "--platform=linux/amd64" ]
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     goos: linux
     goarch: amd64
     goarm: ''
@@ -44,7 +48,11 @@ dockers:
       - watchtower
   - 
     use_buildx: true
-    build_flag_templates: [ "--platform=linux/386" ]
+    build_flag_templates:
+      - "--platform=linux/386"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     goos: linux
     goarch: 386
     goarm: ''
@@ -58,7 +66,11 @@ dockers:
       - watchtower
   - 
     use_buildx: true
-    build_flag_templates: [ "--platform=linux/arm/v6" ]
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     goos: linux
     goarch: arm
     goarm: 6
@@ -72,7 +84,11 @@ dockers:
       - watchtower
   - 
     use_buildx: true
-    build_flag_templates: [ "--platform=linux/arm64/v8" ]
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     goos: linux
     goarch: arm64
     goarm: ''


### PR DESCRIPTION
This PR adds Labels to the Docker Image. The added Labels conform to the [Annotations defined in the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
The following labels are added for releases (dev and tagged):
- `org.opencontainers.image.url`
- `org.opencontainers.image.documentation`
- `org.opencontainers.image.source`
- `org.opencontainers.image.licenses`
- `org.opencontainers.image.title`
- `org.opencontainers.image.description`
- `org.opencontainers.image.base.name`

Tagged releases are additionally labeled with
- `org.opencontainers.image.created`
- `org.opencontainers.image.version`
- `org.opencontainers.image.revision`

Image Labels are considered a best practice for Container Images. They make it easier to handle Images and reconstruct which version one is running. Image Labels also enable tools for automatic dependency updates (like Renovate and Dependabot) to automatically retrieve and display Release Notes for an update.

I tested the changes locally with `goreleaser release --skip-publish --skip-validate --rm-dist`. The images had the expected labels. There are no existing test suites that apply to this change.

Documentation updates are not required for this change.