### PR TITLE
fix: avoid race condition by not running exec/start twice

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -463,13 +463,6 @@ func (client dockerClient) ExecuteCommand(containerID t.ContainerID, command str
 		clog.Errorf("Failed to extract command exec logs: %v", attachErr)
 	}
 
-	// Run the exec
-	execStartCheck := types.ExecStartCheck{Detach: false, Tty: true}
-	err = client.api.ContainerExecStart(bg, exec.ID, execStartCheck)
-	if err != nil {
-		return false, err
-	}
-
 	var output string
 	if attachErr == nil {
 		defer response.Close()

--- a/pkg/container/client_test.go
+++ b/pkg/container/client_test.go
@@ -282,15 +282,6 @@ var _ = Describe("the client", func() {
 						}),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, types.IDResponse{ID: execID}),
 					),
-					// API.ContainerExecStart
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("POST", HaveSuffix("exec/%v/start", execID)),
-						ghttp.VerifyJSONRepresenting(types.ExecStartCheck{
-							Detach: false,
-							Tty:    true,
-						}),
-						ghttp.RespondWith(http.StatusOK, nil),
-					),
 					// API.ContainerExecInspect
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", HaveSuffix("exec/ex-exec-id/json")),


### PR DESCRIPTION
When running with the lifecycle labels, this error is popping up at every interval/upgrade

```
time="2024-04-22T19:16:37Z" level=info msg="Command output:\nError: Exec command c37bb52a3fa2dd1489baf9f92ab17738ec0095b2f86afd9d27b75beee3bf2e31 is already running"
```

Looking more into it, it seems like it's related to https://github.com/moby/moby/issues/42408 which I originally found through https://github.com/nektos/act/issues/627 which is fixed with https://github.com/nektos/act/pull/702

I took the changes and applied similarly to watchtower. I ran it locally with my initial fail test, and it seems to be clean now.

I'm not a go dev, so apologies if I have missed something.