### PR TITLE
fix spelling mistake

### DIFF
--- a/pkg/notifications/notifier_test.go
+++ b/pkg/notifications/notifier_test.go
@@ -28,7 +28,7 @@ var _ = Describe("notifications", func() {
 
 			Expect(notif.GetNames()).To(BeEmpty())
 		})
-		When("title is overriden in flag", func() {
+		When("title is overridden in flag", func() {
 			It("should use the specified hostname in the title", func() {
 				command := cmd.NewRootCommand()
 				flags.RegisterNotificationFlags(command)


### PR DESCRIPTION
I have corrected the spelling of `overriden` to `overridden`.