### PR TITLE
feat: add ability to define original image id and image name used in custom images 

### DIFF
--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -329,10 +329,12 @@ func (client dockerClient) IsContainerStale(container t.Container, params t.Upda
 }
 
 func (client dockerClient) HasNewImage(ctx context.Context, container t.Container) (hasNew bool, latestImage t.ImageID, err error) {
-	currentImageID := t.ImageID(container.ContainerInfo().ContainerJSONBase.Image)
+	container_info := container.ContainerInfo()
+	currentImageID := t.ImageID(container_info.ContainerJSONBase.Image)
 	imageName := container.ImageName()
 
-	imageIDSetByLabel, ok := container.ContainerInfo().Config.Labels[originalImageIDLabel]
+	// If the original-image-id label is set, it overwrites the image id reported by docker
+	imageIDSetByLabel, ok := container_info.Config.Labels[originalImageIDLabel]
 	if ok {
 		currentImageID = t.ImageID(imageIDSetByLabel)
 		log.Infof("Original image id for %s found: (%s)", imageName, currentImageID.ShortID())

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -332,6 +332,12 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 	currentImageID := t.ImageID(container.ContainerInfo().ContainerJSONBase.Image)
 	imageName := container.ImageName()
 
+	imageIDSetByLabel, ok := container.ContainerInfo().Config.Labels[originalImageIDLabel]
+	if ok {
+		currentImageID = t.ImageID(imageIDSetByLabel)
+		log.Infof("Original image id for %s found: (%s)", imageName, currentImageID.ShortID())
+	}
+
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)
 	if err != nil {
 		return false, currentImageID, err

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -337,7 +337,7 @@ func (client dockerClient) HasNewImage(ctx context.Context, container t.Containe
 	imageIDSetByLabel, ok := container_info.Config.Labels[originalImageIDLabel]
 	if ok {
 		currentImageID = t.ImageID(imageIDSetByLabel)
-		log.Infof("Original image id for %s found: (%s)", imageName, currentImageID.ShortID())
+		log.Debugf("Original image id for %s found: (%s)", imageName, currentImageID.ShortID())
 	}
 
 	newImageInfo, _, err := client.api.ImageInspectWithRaw(ctx, imageName)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -103,7 +103,11 @@ func (c Container) SafeImageID() wt.ImageID {
 // "latest" tag is assumed.
 func (c Container) ImageName() string {
 	// Compatibility w/ Zodiac deployments
-	imageName, ok := c.getLabelValue(originalImageNameLabel)
+	imageName, ok := c.getLabelValue(zodiacLabel)
+	// If the original-image-name label is set, it overwrites the image name reported by docker
+	if !ok {
+		imageName, ok = c.getLabelValue(originalImageNameLabel)
+	}
 	if !ok {
 		imageName = c.containerInfo.Config.Image
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -103,7 +103,7 @@ func (c Container) SafeImageID() wt.ImageID {
 // "latest" tag is assumed.
 func (c Container) ImageName() string {
 	// Compatibility w/ Zodiac deployments
-	imageName, ok := c.getLabelValue(zodiacLabel)
+	imageName, ok := c.getLabelValue(originalImageNameLabel)
 	if !ok {
 		imageName = c.containerInfo.Config.Image
 	}

--- a/pkg/container/metadata.go
+++ b/pkg/container/metadata.go
@@ -10,6 +10,8 @@ const (
 	noPullLabel            = "com.centurylinklabs.watchtower.no-pull"
 	dependsOnLabel         = "com.centurylinklabs.watchtower.depends-on"
 	zodiacLabel            = "com.centurylinklabs.zodiac.original-image"
+	originalImageNameLabel = "com.centurylinklabs.watchtower.original-image"
+	originalImageIDLabel   = "com.centurylinklabs.watchtower.original-image-id"
 	scope                  = "com.centurylinklabs.watchtower.scope"
 	preCheckLabel          = "com.centurylinklabs.watchtower.lifecycle.pre-check"
 	postCheckLabel         = "com.centurylinklabs.watchtower.lifecycle.post-check"


### PR DESCRIPTION
TL;DR: This PR allows one to add two labels to containers that define which original image was used as the base of the image being run. 

## The problem

Sometimes it is necessary to build a custom docker image that only slightly changes a base image. For example:

```
FROM nginx:1.25.4
COPY nginx.conf /etc/nginx/nginx.conf
```

When running this custom image, watchtower cannot figure out that the base nginx image is stale, as it instead only checks if our custom nginx image is stale:

```
Could not do a head request for "custom-nginx:latest", falling back to regular pull.
Reason: registry responded to head request with "401 Unauthorized", auth: "Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/nginx-as-container-rootnginx:pull\",error=\"insufficient_scope\""
Unable to update container "custom-nginx-1": Error response from daemon: pull access denied for custom-nginx, repository does not exist or may require 'docker login': denied: requested access to the resource is denied. Proceeding to next.
```

## The solution

With this PR, it is possible to add two labels to the container that overwrites the image ID and image name used by watchtower to decide whether the image is stale:

```
docker run -d \
   -l com.centurylinklabs.watchtower.original-image=nginx \
   -l com.centurylinklabs.watchtower.original-image-id=$(docker inspect nginx:1.25.4 | jq '.[0]'.Id) \
   -l com.centurylinklabs.watchtower.monitor-only=1 \
    custom_nginx
```

Now, watchtower reports a new nginx version:

```
$ ./watchtower --run-once
INFO[0001] Watchtower v0.0.0-unknown                    
INFO[0001] Using no notifications                       
INFO[0001] Checking all containers (except explicitly disabled with label) 
INFO[0001] Running a one time update.                   
INFO[0003] Original image id for nginx:latest found: ("sha256:c613f16b6642) 
INFO[0003] Found new nginx:latest image (1d668e06f1e5)
```

## Current limitations

Currently automatic updating of the images will break the containers as it will replace the container using images of the original base image. Here it would start `nginx:1.25.5` instead of a custom version of it. 
Thus, it is necessary to set `monitor-only=1`.

## Further work

I haven't done: "Tests that verify the code your contributing" and "Updates to the documentation" because I wanted to wait and see if this feature is even desired. 

Feel free to reject the PR if the feature does not fit within the scope of this project.

<!--

Thank you for contributing to the watchtower project! 🙏

We truly appreciate all the contributions we get from the community.

To make your PR experience as smooth as possible, make sure that you
include the following in your PR:

- What your PR contributes
- Which issues it solves (preferrably using auto closing instructions like "closes #123".
- Tests that verify the code your contributing
- Updates to the documentation

Thank you again! ✨

-->
