### PR TITLE
Remove obsolete version from docker-compose.yaml reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,6 @@ the following command:
 === "docker-compose.yml"
 
     ```yaml
-    version: "3"
     services:
       watchtower:
         image: containrrr/watchtower


### PR DESCRIPTION
This PR removes the obsolete `version` from the docker-compose.yaml reference in the docs.

If this is added, you get following warning:
```
WARN[0000] /home/jonas/watchtower/docker-compose.yaml: `version` is obsolete
```