### PR TITLE
fix notification docs Custom date format tip

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -55,7 +55,7 @@ outputs timestamp and log level.
     If you want to adjust the date/time format it must show how the
     [reference time](https://golang.org/pkg/time/#pkg-constants) (_Mon Jan 2 15:04:05 MST 2006_) would be displayed in your
     custom format.  
-    i.e., The day of the year has to be 1, the month has to be 2 (february), the hour 3 (or 15 for 24h time) etc.
+    i.e., The day of the year has to be 2, the month has to be 1 (january), the hour 3 (or 15 for 24h time) etc.
 
 !!! note "Skipping notifications"
     To skip sending notifications that do not contain any information, you can wrap your template with `{{if .}}` and `{{end}}`.


### PR DESCRIPTION
just fixing a small mistake in the docs
notifications "Custom date format" tip

the reference time is `Mon Jan 2 15:04:05 MST 2006`
and the tip said 1st day and  2nd month (february)
when it should say 2nd day and 1st month (january)