### PR TITLE
add optional image tag filter

### DIFF
--- a/docs/http-api-mode.md
+++ b/docs/http-api-mode.md
@@ -43,3 +43,8 @@ In order to update only certain images, the image names can be provided as URL q
 ```bash
 curl -H "Authorization: Bearer mytoken" localhost:8080/v1/update?image=foo/bar,foo/baz
 ```
+
+tags are also supported:
+```bash
+curl -H "Authorization: Bearer mytoken" localhost:8080/v1/update?image=foo/baz:latest
+```

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -108,9 +108,15 @@ func FilterByImage(images []string, baseFilter t.Filter) t.Filter {
 	}
 
 	return func(c t.FilterableContainer) bool {
-		image := strings.Split(c.ImageName(), ":")[0]
+		imageParts := strings.Split(c.ImageName(), ":")
 		for _, targetImage := range images {
-			if image == targetImage {
+			targetImageParts := strings.Split(targetImage, ":")
+			if imageParts[0] == targetImageParts[0] {
+				if len(imageParts) == 2 && len(targetImageParts) == 2 {
+					if imageParts[1] != targetImageParts[1] {
+						continue
+					}
+				}
 				return baseFilter(c)
 			}
 		}

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -213,6 +213,32 @@ func TestFilterByImage(t *testing.T) {
 	assert.True(t, filterMultiple(container))
 	container.AssertExpectations(t)
 
+	filterEmptyTagged := FilterByImage(nil, NoFilter)
+	filterSingleTagged := FilterByImage([]string{"registry:develop"}, NoFilter)
+	filterMultipleTagged := FilterByImage([]string{"registry:develop", "registry:latest"}, NoFilter)
+	assert.NotNil(t, filterSingleTagged)
+	assert.NotNil(t, filterMultipleTagged)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("bla:latest")
+	assert.True(t, filterEmptyTagged(container))
+	assert.False(t, filterSingleTagged(container))
+	assert.False(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("registry:latest")
+	assert.True(t, filterEmptyTagged(container))
+	assert.False(t, filterSingleTagged(container))
+	assert.True(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
+
+	container = new(mocks.FilterableContainer)
+	container.On("ImageName").Return("registry:develop")
+	assert.True(t, filterEmptyTagged(container))
+	assert.True(t, filterSingleTagged(container))
+	assert.True(t, filterMultipleTagged(container))
+	container.AssertExpectations(t)
 }
 
 func TestBuildFilter(t *testing.T) {


### PR DESCRIPTION
To be able to do finegrained updates to container running a specific tag of an image i added this.

closes #1932