### PR TITLE
Improve Error Handling and Dependency Checks in build.sh file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# check if `go` is installed or not
+if ! command -v go &> /dev/null; then
+    echo "Error: Go is not installed. Please install Go before running this script."
+    exit 1
+fi
+
 BINFILE=watchtower
 if [ -n "$MSYSTEM" ]; then
     BINFILE=watchtower.exe
@@ -7,3 +13,10 @@ fi
 VERSION=$(git describe --tags)
 echo "Building $VERSION..."
 go build -o $BINFILE -ldflags "-X github.com/containrrr/watchtower/internal/meta.Version=$VERSION"
+
+if [ $? -ne 0 ]; then
+    echo "Error: Build failed!"
+    exit 1
+fi
+
+echo "Build successful!"


### PR DESCRIPTION
Although the project says to have GO as a prereq, having something to catch and check the dependency beforehand helps.

Therefore, refactoring the script to add the check first before running to handle the script run in a better way.

Issue: The script does not check for Go installation before running go build.
Fix: Added a dependency check to prevent build failures.