### PR TITLE
Fix Unsafe Command Expansion in build-tplprev.sh

### DIFF
--- a/scripts/build-tplprev.sh
+++ b/scripts/build-tplprev.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
-cd $(git rev-parse --show-toplevel)
+# get the repo root directory safely
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || { echo "Error: Failed to change directory"; exit 1; }
 
 cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" ./docs/assets/
 
+# build webassembly binary
 GOARCH=wasm GOOS=js go build -o ./docs/assets/tplprev.wasm ./tplprev
+if [ $? -ne 0 ]; then
+    echo "Error: WASM build failed!"
+    exit 1
+fi
+
+echo "WASM build successful!"


### PR DESCRIPTION
The script uses `cd $(git rev-parse --show-toplevel)`, which fails if the path has spaces.

Therefore, replaced `cd $(command)` with `cd "$(command)"` to properly handle spaces.

After these changes. it prevents build failures due to incorrect path handling and improves error reporting too.
