### PR TITLE
fix: Docker v29 minimum api version

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -17,7 +17,7 @@ import (
 
 // DockerAPIMinVersion is the minimum version of the docker api required to
 // use watchtower
-const DockerAPIMinVersion string = "1.25"
+const DockerAPIMinVersion string = "1.44"
 
 var defaultInterval = int((time.Hour * 24).Seconds())
 


### PR DESCRIPTION
Following the Docker's (moby) breaking change: https://github.com/moby/moby/releases/tag/docker-v29.0.0

Fixing https://github.com/containrrr/watchtower/issues/2126 : `Error response from daemon: client version 1.25 is too old`

